### PR TITLE
Add Agent CI Docker image maniest

### DIFF
--- a/.github/agent-ci.Dockerfile
+++ b/.github/agent-ci.Dockerfile
@@ -1,0 +1,4 @@
+FROM ghcr.io/actions/actions-runner:latest
+RUN sudo apt-get update \
+ && sudo apt-get install -y --no-install-recommends build-essential \
+ && sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The Agent CI images are minimal, we need to add `cc`, for example,
ourselves.
