### PR TITLE
Show an empty state when a workspace has no terminals

### DIFF
--- a/ui/app.rs
+++ b/ui/app.rs
@@ -438,6 +438,45 @@ window {
   font-size: 13px;
 }
 
+.terminal-placeholder {
+  padding: 24px;
+}
+
+.terminal-placeholder-icon {
+  color: #55627a;
+  margin-bottom: 16px;
+}
+
+.terminal-placeholder-title {
+  color: #c3ccd9;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.terminal-placeholder-subtitle {
+  color: #6f7887;
+  font-size: 12px;
+  margin-bottom: 20px;
+}
+
+.terminal-placeholder-action {
+  min-height: 32px;
+  padding: 0 18px;
+  background: rgba(126, 203, 255, 0.10);
+  color: #b6dcff;
+  border: 1px solid rgba(143, 202, 255, 0.28);
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.terminal-placeholder-action:hover {
+  background: rgba(126, 203, 255, 0.18);
+  color: #eaf5ff;
+  border-color: rgba(143, 202, 255, 0.5);
+}
+
 .terminal-host scrollbar {
   background: transparent;
   margin: 2px 4px 2px 0;

--- a/ui/workspace_panel.rs
+++ b/ui/workspace_panel.rs
@@ -1,4 +1,6 @@
-use gtk::{glib, prelude::*, Align, Box as GtkBox, Button, LinkButton, Orientation, Stack};
+use gtk::{
+    glib, prelude::*, Align, Box as GtkBox, Button, Image, Label, LinkButton, Orientation, Stack,
+};
 use std::{cell::RefCell, collections::HashMap, path::Path, rc::Rc, sync::mpsc, time::Duration};
 use swarm::forges::github::{self, PullRequestStatus};
 
@@ -78,6 +80,10 @@ impl DetailWidgets {
     pub fn render_empty(&self) {
         clear_box(&self.session_toolbar);
         clear_stack(&self.session_stack);
+
+        let placeholder = build_no_workspace_placeholder();
+        self.session_stack
+            .add_titled(&placeholder, Some("empty"), "empty");
     }
 
     pub fn render_workspace(
@@ -129,14 +135,7 @@ impl DetailWidgets {
         }
 
         if workspace.sessions.is_empty() {
-            let empty = ghostty::terminal_host(&SessionEntry {
-                id: "No sessions".to_string(),
-                pid: None,
-                program: "No sessions".to_string(),
-                status: "idle".to_string(),
-                log_path: String::new(),
-                socket_path: String::new(),
-            });
+            let empty = build_empty_session_placeholder(state, workspace);
             self.session_stack
                 .add_titled(&empty, Some("empty"), "empty");
             return;
@@ -256,6 +255,70 @@ impl DetailWidgets {
             WorkspacePrState::Loading => {}
         }
     }
+}
+
+fn build_placeholder(title: &str, subtitle: &str) -> GtkBox {
+    let container = GtkBox::new(Orientation::Vertical, 0);
+    container.set_hexpand(true);
+    container.set_vexpand(true);
+    container.set_halign(Align::Center);
+    container.set_valign(Align::Center);
+    container.add_css_class("terminal-placeholder");
+
+    let icon = Image::from_icon_name("utilities-terminal-symbolic");
+    icon.set_pixel_size(28);
+    icon.set_halign(Align::Center);
+    icon.add_css_class("terminal-placeholder-icon");
+
+    let title_label = Label::new(Some(title));
+    title_label.add_css_class("terminal-placeholder-title");
+
+    let subtitle_label = Label::new(Some(subtitle));
+    subtitle_label.add_css_class("terminal-placeholder-subtitle");
+
+    container.append(&icon);
+    container.append(&title_label);
+    container.append(&subtitle_label);
+    container
+}
+
+fn build_empty_session_placeholder(state: &Rc<AppState>, workspace: &WorkspaceEntry) -> GtkBox {
+    let label = if workspace.branch.is_empty() {
+        workspace.name.as_str()
+    } else {
+        workspace.branch.as_str()
+    };
+    let container = build_placeholder("No terminal open", &format!("Start a terminal in {label}."));
+
+    let new_terminal = Button::new();
+    new_terminal.set_halign(Align::Center);
+    new_terminal.add_css_class("terminal-placeholder-action");
+
+    let button_content = GtkBox::new(Orientation::Horizontal, 8);
+    button_content.set_halign(Align::Center);
+    let button_icon = Image::from_icon_name("utilities-terminal-symbolic");
+    button_icon.set_pixel_size(14);
+    button_content.append(&button_icon);
+    button_content.append(&Label::new(Some("New Terminal")));
+    new_terminal.set_child(Some(&button_content));
+
+    {
+        let state = state.clone();
+        let workspace_id = workspace_ref(workspace);
+        new_terminal.connect_clicked(move |_| {
+            create_and_select_session(&state, &workspace_id);
+        });
+    }
+
+    container.append(&new_terminal);
+    container
+}
+
+fn build_no_workspace_placeholder() -> GtkBox {
+    build_placeholder(
+        "No workspace selected",
+        "Pick a workspace in the sidebar to open a terminal.",
+    )
 }
 
 fn build_workspace_pr_link(status: &PullRequestStatus) -> Option<LinkButton> {


### PR DESCRIPTION
Replace the placeholder terminal host with a centered panel that has a terminal icon, a title, and a "New Terminal" button that opens a session in the selected workspace. The subtitle names the workspace branch.

When no workspace is selected, the same panel is shown without the button.