### PR TITLE
Stop leaking terminal state and refresh workers

### DIFF
--- a/ui/app.rs
+++ b/ui/app.rs
@@ -2043,6 +2043,16 @@ fn remove_selected_workspace(state: &Rc<AppState>, workspace: &WorkspaceEntry) {
     let removed_workspace_ref = workspace_ref(workspace);
     match remove_workspace(&removed_workspace_ref) {
         Ok(_) => {
+            // Drop the cached terminals of the removed sessions, otherwise their
+            // widgets stay alive and keep polling a socket that is already gone.
+            if let Some(detail_widgets) = state.detail_widgets.borrow().as_ref() {
+                detail_widgets.evict_terminals(
+                    workspace
+                        .sessions
+                        .iter()
+                        .map(|session| session.id.as_str()),
+                );
+            }
             clear_workspace_pr_status(state, &removed_workspace_ref);
             let mut next_groups = state.workspace_groups.borrow().clone();
             for group in &mut next_groups {

--- a/ui/ghostty.rs
+++ b/ui/ghostty.rs
@@ -93,13 +93,15 @@ pub fn terminal_host(session: &SessionEntry) -> GtkBox {
     );
     state.borrow_mut().refresh_view();
 
-    install_draw_func(&area, state.clone());
-    install_key_controller(&area, state.clone());
-    install_scroll_controller(&area, state.clone());
-    install_focus_controller(&area, state.clone());
-    install_drag_controller(&area, state.clone());
-    install_context_menu(&area, state.clone());
-    install_scrollbar_sync(&adjustment, state.clone());
+    install_draw_func(&area, &state);
+    install_key_controller(&area, &state);
+    install_scroll_controller(&area, &state);
+    install_focus_controller(&area, &state);
+    install_drag_controller(&area, &state);
+    install_context_menu(&area, &state);
+    install_scrollbar_sync(&adjustment, &state);
+    // The socket pump owns the only strong reference: the widget closures below
+    // hold weak ones, so the terminal is freed once its widget is dropped.
     install_socket_pump(state);
 
     {
@@ -111,8 +113,12 @@ pub fn terminal_host(session: &SessionEntry) -> GtkBox {
     container
 }
 
-fn install_draw_func(area: &DrawingArea, state: Rc<RefCell<SessionTerminalState>>) {
+fn install_draw_func(area: &DrawingArea, state: &Rc<RefCell<SessionTerminalState>>) {
+    let state = Rc::downgrade(state);
     area.set_draw_func(move |_area, cr, width, height| {
+        let Some(state) = state.upgrade() else {
+            return;
+        };
         if let Ok(mut state) = state.try_borrow_mut() {
             state.draw(cr, width, height);
         }
@@ -131,14 +137,17 @@ fn install_socket_pump(state: Rc<RefCell<SessionTerminalState>>) {
     });
 }
 
-fn install_key_controller(area: &DrawingArea, state: Rc<RefCell<SessionTerminalState>>) {
+fn install_key_controller(area: &DrawingArea, state: &Rc<RefCell<SessionTerminalState>>) {
     let controller = EventControllerKey::new();
     let im_context = IMMulticontext::new();
     im_context.set_client_widget(Some(area));
     im_context.set_use_preedit(false);
     {
-        let state = state.clone();
+        let state = Rc::downgrade(state);
         im_context.connect_commit(move |_context, text| {
+            let Some(state) = state.upgrade() else {
+                return;
+            };
             if let Ok(mut state) = state.try_borrow_mut() {
                 state.send_text(text);
             }
@@ -146,7 +155,12 @@ fn install_key_controller(area: &DrawingArea, state: Rc<RefCell<SessionTerminalS
     }
     controller.set_im_context(Some(&im_context));
     let area_for_clipboard = area.clone();
+    let state = Rc::downgrade(state);
     controller.connect_key_pressed(move |controller, key, _keycode, modifiers| {
+        let Some(state) = state.upgrade() else {
+            return glib::Propagation::Proceed;
+        };
+
         if is_paste_shortcut(key, modifiers) {
             paste_from_clipboard(&area_for_clipboard, state.clone(), false);
             return glib::Propagation::Stop;
@@ -170,7 +184,7 @@ fn install_key_controller(area: &DrawingArea, state: Rc<RefCell<SessionTerminalS
     area.add_controller(controller);
 }
 
-fn install_context_menu(area: &DrawingArea, state: Rc<RefCell<SessionTerminalState>>) {
+fn install_context_menu(area: &DrawingArea, state: &Rc<RefCell<SessionTerminalState>>) {
     let menu = gio::Menu::new();
     menu.append(Some("Copy"), Some("term.copy"));
     menu.append(Some("Paste"), Some("term.paste"));
@@ -184,8 +198,11 @@ fn install_context_menu(area: &DrawingArea, state: Rc<RefCell<SessionTerminalSta
     let copy_action = gio::SimpleAction::new("copy", None);
     {
         let area = area.clone();
-        let state = state.clone();
+        let state = Rc::downgrade(state);
         copy_action.connect_activate(move |_, _| {
+            let Some(state) = state.upgrade() else {
+                return;
+            };
             if let Ok(mut s) = state.try_borrow_mut() {
                 if let Some(text) = s.copy_selection_text() {
                     area.clipboard().set_text(&text);
@@ -198,9 +215,12 @@ fn install_context_menu(area: &DrawingArea, state: Rc<RefCell<SessionTerminalSta
     let paste_action = gio::SimpleAction::new("paste", None);
     {
         let area = area.clone();
-        let state = state.clone();
+        let state = Rc::downgrade(state);
         paste_action.connect_activate(move |_, _| {
-            paste_from_clipboard(&area, state.clone(), false);
+            let Some(state) = state.upgrade() else {
+                return;
+            };
+            paste_from_clipboard(&area, state, false);
         });
     }
     action_group.add_action(&paste_action);
@@ -226,23 +246,37 @@ fn install_context_menu(area: &DrawingArea, state: Rc<RefCell<SessionTerminalSta
         });
     }
     area.add_controller(gesture);
+
+    // GTK4 requires popovers to be unparented before their parent is finalized.
+    {
+        let popover = popover.clone();
+        area.connect_destroy(move |_| {
+            popover.unparent();
+        });
+    }
 }
 
-fn install_drag_controller(area: &DrawingArea, state: Rc<RefCell<SessionTerminalState>>) {
+fn install_drag_controller(area: &DrawingArea, state: &Rc<RefCell<SessionTerminalState>>) {
     let drag = GestureDrag::new();
     drag.set_button(gdk::BUTTON_PRIMARY);
     {
-        let state = state.clone();
+        let state = Rc::downgrade(state);
         drag.connect_drag_begin(move |_drag, x, y| {
+            let Some(state) = state.upgrade() else {
+                return;
+            };
             if let Ok(mut s) = state.try_borrow_mut() {
                 s.begin_selection(x, y);
             }
         });
     }
     {
-        let state = state.clone();
+        let state = Rc::downgrade(state);
         drag.connect_drag_update(move |drag, dx, dy| {
             let Some((sx, sy)) = drag.start_point() else {
+                return;
+            };
+            let Some(state) = state.upgrade() else {
                 return;
             };
             if let Ok(mut s) = state.try_borrow_mut() {
@@ -252,8 +286,12 @@ fn install_drag_controller(area: &DrawingArea, state: Rc<RefCell<SessionTerminal
     }
     {
         let area = area.clone();
+        let state = Rc::downgrade(state);
         drag.connect_drag_end(move |drag, dx, dy| {
             let Some((sx, sy)) = drag.start_point() else {
+                return;
+            };
+            let Some(state) = state.upgrade() else {
                 return;
             };
             let text_opt = if let Ok(mut s) = state.try_borrow_mut() {
@@ -270,9 +308,13 @@ fn install_drag_controller(area: &DrawingArea, state: Rc<RefCell<SessionTerminal
     area.add_controller(drag);
 }
 
-fn install_scroll_controller(area: &DrawingArea, state: Rc<RefCell<SessionTerminalState>>) {
+fn install_scroll_controller(area: &DrawingArea, state: &Rc<RefCell<SessionTerminalState>>) {
     let controller = EventControllerScroll::new(EventControllerScrollFlags::VERTICAL);
+    let state = Rc::downgrade(state);
     controller.connect_scroll(move |_controller, _dx, dy| {
+        let Some(state) = state.upgrade() else {
+            return glib::Propagation::Proceed;
+        };
         if let Ok(mut state) = state.try_borrow_mut() {
             state.scroll_by_delta(dy);
         }
@@ -281,23 +323,30 @@ fn install_scroll_controller(area: &DrawingArea, state: Rc<RefCell<SessionTermin
     area.add_controller(controller);
 }
 
-fn install_scrollbar_sync(adjustment: &Adjustment, state: Rc<RefCell<SessionTerminalState>>) {
+fn install_scrollbar_sync(adjustment: &Adjustment, state: &Rc<RefCell<SessionTerminalState>>) {
+    let state = Rc::downgrade(state);
     adjustment.connect_value_changed(move |adjustment| {
+        let Some(state) = state.upgrade() else {
+            return;
+        };
         if let Ok(mut state) = state.try_borrow_mut() {
             state.handle_adjustment_change(adjustment.value().round() as u64);
         }
     });
 }
 
-fn install_focus_controller(area: &DrawingArea, state: Rc<RefCell<SessionTerminalState>>) {
+fn install_focus_controller(area: &DrawingArea, state: &Rc<RefCell<SessionTerminalState>>) {
     let controller = GestureClick::new();
     {
         let area = area.clone();
-        let state = state.clone();
+        let state = Rc::downgrade(state);
         controller.connect_pressed(move |gesture, _n_press, _x, _y| {
             area.grab_focus();
             if gesture.current_button() == 2 {
-                paste_from_clipboard(&area, state.clone(), true);
+                let Some(state) = state.upgrade() else {
+                    return;
+                };
+                paste_from_clipboard(&area, state, true);
             }
         });
     }

--- a/ui/workspace_panel.rs
+++ b/ui/workspace_panel.rs
@@ -1,7 +1,14 @@
 use gtk::{
     glib, prelude::*, Align, Box as GtkBox, Button, Image, Label, LinkButton, Orientation, Stack,
 };
-use std::{cell::RefCell, collections::HashMap, path::Path, rc::Rc, sync::mpsc, time::Duration};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    path::Path,
+    rc::Rc,
+    sync::{mpsc, Arc, Mutex},
+    time::Duration,
+};
 use swarm::forges::github::{self, PullRequestStatus};
 
 use crate::{
@@ -23,7 +30,12 @@ pub struct DetailWidgets {
     session_toolbar_spacer: GtkBox,
     pub session_stack: Stack,
     terminal_cache: Rc<RefCell<HashMap<String, GtkBox>>>,
+    tracked_sessions: TrackedSessions,
 }
+
+/// Sessions whose foreground program the refresh worker polls, as
+/// `(session id, pid, fallback program)`.
+type TrackedSessions = Arc<Mutex<Vec<(String, Option<u32>, String)>>>;
 
 impl DetailWidgets {
     pub fn new(state: &Rc<AppState>) -> Self {
@@ -67,6 +79,9 @@ impl DetailWidgets {
         container.append(&session_toolbar);
         container.append(&session_stack);
 
+        let tracked_sessions: TrackedSessions = Arc::new(Mutex::new(Vec::new()));
+        install_session_program_refresh(&session_tabs, tracked_sessions.clone());
+
         Self {
             container,
             session_toolbar,
@@ -74,12 +89,14 @@ impl DetailWidgets {
             session_toolbar_spacer,
             session_stack,
             terminal_cache: Rc::new(RefCell::new(HashMap::new())),
+            tracked_sessions,
         }
     }
 
     pub fn render_empty(&self) {
         clear_box(&self.session_toolbar);
         clear_stack(&self.session_stack);
+        self.track_session_programs(&[]);
 
         let placeholder = build_no_workspace_placeholder();
         self.session_stack
@@ -135,6 +152,7 @@ impl DetailWidgets {
         }
 
         if workspace.sessions.is_empty() {
+            self.track_session_programs(&[]);
             let empty = build_empty_session_placeholder(state, workspace);
             self.session_stack
                 .add_titled(&empty, Some("empty"), "empty");
@@ -182,7 +200,25 @@ impl DetailWidgets {
             self.session_tabs.append(&tab);
         }
         sync_session_tab_active_state(&self.session_tabs, Some(&selected_session));
-        install_session_tab_refresh(&self.session_tabs, &workspace.sessions);
+        self.track_session_programs(&workspace.sessions);
+    }
+
+    fn track_session_programs(&self, sessions: &[SessionEntry]) {
+        let Ok(mut tracked) = self.tracked_sessions.lock() else {
+            return;
+        };
+
+        *tracked = sessions
+            .iter()
+            .map(|session| (session.id.clone(), session.pid, session.program.clone()))
+            .collect();
+    }
+
+    pub fn evict_terminals<'a>(&self, session_ids: impl IntoIterator<Item = &'a str>) {
+        let mut cache = self.terminal_cache.borrow_mut();
+        for session_id in session_ids {
+            cache.remove(session_id);
+        }
     }
 
     fn refresh_in_place(
@@ -556,17 +592,20 @@ fn build_session_tab(
     tab
 }
 
-fn install_session_tab_refresh(session_tabs: &GtkBox, sessions: &[SessionEntry]) {
+fn install_session_program_refresh(session_tabs: &GtkBox, tracked: TrackedSessions) {
     let session_tabs = session_tabs.downgrade();
-    let session_info: Vec<(String, Option<u32>, String)> = sessions
-        .iter()
-        .map(|s| (s.id.clone(), s.pid, s.program.clone()))
-        .collect();
-    let (tx, rx) = std::sync::mpsc::channel::<Vec<(String, String)>>();
+    let (tx, rx) = mpsc::channel::<Vec<(String, String)>>();
 
     std::thread::spawn(move || loop {
         std::thread::sleep(Duration::from_secs(1));
-        let programs: Vec<(String, String)> = session_info
+        let Ok(sessions) = tracked.lock().map(|sessions| sessions.clone()) else {
+            break;
+        };
+        if sessions.is_empty() {
+            continue;
+        }
+
+        let programs: Vec<(String, String)> = sessions
             .iter()
             .map(|(id, pid, fallback)| {
                 let program = foreground_program(*pid).unwrap_or_else(|| fallback.clone());
@@ -651,10 +690,7 @@ fn close_specific_session(
     match close_session(session_id) {
         Ok(_) => {
             if let Some(detail_widgets) = state.detail_widgets.borrow().as_ref() {
-                detail_widgets
-                    .terminal_cache
-                    .borrow_mut()
-                    .remove(session_id);
+                detail_widgets.evict_terminals([session_id]);
             }
             let preferred_session = next_selected.clone();
             let mut next_groups = current_groups(state);


### PR DESCRIPTION
The session program refresh spawned a worker thread and a 250 ms main loop timer on every full render, and neither ever stopped because the tabs box it watched is retained for the lifetime of the process. Install both once and keep the tracked session list in shared state instead.

Terminals of removed workspaces stayed in the terminal cache, so their socket pump kept polling a session that no longer exists. Evict them when the workspace is removed.

Evicting was not enough on its own: the widget closures held strong references to the terminal state, which owns the drawing area, so the state was never dropped. Hold weak references in those closures and let the socket pump own the only strong one.