### PR TITLE
Stop blocking the GTK main thread in UI actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ pangocairo = { version = "0.21", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 turso = "0.4"
 
 [[bin]]

--- a/sessions.rs
+++ b/sessions.rs
@@ -313,7 +313,7 @@ impl SessionStore {
                 )));
             }
 
-            std::thread::sleep(Duration::from_millis(50));
+            tokio::time::sleep(Duration::from_millis(50)).await;
         }
     }
 

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -534,6 +534,7 @@ fn build_ui(app: &Application) {
         pending_pr_lookups: RefCell::new(HashSet::new()),
         creating_pr_workspaces: RefCell::new(HashSet::new()),
         creating_session_workspaces: RefCell::new(HashSet::new()),
+        closing_sessions: RefCell::new(HashSet::new()),
     });
 
     let sidebar_widgets = build_sidebar_widgets(&state);
@@ -570,6 +571,7 @@ pub struct AppState {
     pending_pr_lookups: RefCell<HashSet<String>>,
     pub(crate) creating_pr_workspaces: RefCell<HashSet<String>>,
     pub(crate) creating_session_workspaces: RefCell<HashSet<String>>,
+    pub(crate) closing_sessions: RefCell<HashSet<String>>,
 }
 
 #[derive(Clone)]

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -648,8 +648,16 @@ struct CachedPrStatus {
 #[derive(Clone)]
 pub enum WorkspacePrState {
     Loading,
-    None,
+    None(CreatePrEligibility),
     Ready(PullRequestStatus),
+}
+
+/// Whether the workspace can offer a "Create PR" button, resolved in the
+/// background PR status lookup so rendering never runs git.
+#[derive(Clone, Copy, Default)]
+pub struct CreatePrEligibility {
+    pub is_github: bool,
+    pub commits_ahead: Option<u32>,
 }
 
 fn refresh_ui(
@@ -887,7 +895,7 @@ fn pr_status_ttl(state: &WorkspacePrState, is_selected: bool) -> Duration {
 
     match state {
         WorkspacePrState::Loading => LOADING_PR_STATUS_TTL,
-        WorkspacePrState::None => NO_PR_STATUS_TTL,
+        WorkspacePrState::None(_) => NO_PR_STATUS_TTL,
         WorkspacePrState::Ready(status) => match status.state {
             PullRequestStatusState::Pending => PENDING_PR_STATUS_TTL,
             PullRequestStatusState::Success | PullRequestStatusState::Failure => {
@@ -935,12 +943,24 @@ pub(crate) fn request_workspace_pr_status(
     let state = state.clone();
     exec::dispatch_blocking(
         move || {
+            let path = Path::new(&workspace_path);
             let head = current_workspace_head(&workspace_path).ok();
-            let status = github::workspace_pull_request_status(Path::new(&workspace_path));
-            (status, head)
+            let status = github::workspace_pull_request_status(path);
+            let eligibility = if status.is_none() {
+                let is_github = github::is_github_workspace(path);
+                CreatePrEligibility {
+                    is_github,
+                    commits_ahead: is_github
+                        .then(|| github::workspace_commits_ahead(path))
+                        .flatten(),
+                }
+            } else {
+                CreatePrEligibility::default()
+            };
+            (status, head, eligibility)
         },
-        move |(status, head)| {
-            apply_workspace_pr_update(&state, workspace_id, status, head);
+        move |(status, head, eligibility)| {
+            apply_workspace_pr_update(&state, workspace_id, status, head, eligibility);
         },
     );
 }
@@ -950,6 +970,7 @@ fn apply_workspace_pr_update(
     workspace_ref: String,
     status: Option<PullRequestStatus>,
     head: Option<String>,
+    eligibility: CreatePrEligibility,
 ) {
     let selected_workspace = state.selected_workspace.borrow().clone();
     let selected_workspace_changed =
@@ -960,7 +981,7 @@ fn apply_workspace_pr_update(
         CachedPrStatus {
             state: status
                 .map(WorkspacePrState::Ready)
-                .unwrap_or(WorkspacePrState::None),
+                .unwrap_or(WorkspacePrState::None(eligibility)),
             fetched_at: Instant::now(),
             head,
         },
@@ -1690,7 +1711,7 @@ fn build_workspace_status_indicator(state: &Rc<AppState>, workspace: &WorkspaceE
         WorkspacePrState::Loading => {
             indicator.set_tooltip_text(Some("Loading pull request status..."));
         }
-        WorkspacePrState::None => {
+        WorkspacePrState::None(_) => {
             indicator.set_tooltip_text(Some("No pull request"));
         }
         WorkspacePrState::Ready(status) => {

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -20,7 +20,7 @@ use swarm::forges::github::{self, PullRequestStatus, PullRequestStatusState};
 use crate::{
     data::{
         add_repository, clone_workspace, create_workspace, current_workspace_branch,
-        current_workspace_head, load_workspace_groups, remove_workspace, rename_workspace,
+        load_workspace_groups, read_workspace_head, remove_workspace, rename_workspace,
         set_repository_collapsed, sync_repository, workspace_head_path, WorkspaceEntry,
         WorkspaceGroup,
     },
@@ -907,7 +907,7 @@ fn pr_status_ttl(state: &WorkspacePrState, is_selected: bool) -> Duration {
 }
 
 fn workspace_pr_head_changed(cached: &CachedPrStatus, workspace: &WorkspaceEntry) -> bool {
-    let Ok(current_head) = current_workspace_head(&workspace.path) else {
+    let Ok(current_head) = read_workspace_head(&workspace.path) else {
         return false;
     };
 
@@ -944,7 +944,7 @@ pub(crate) fn request_workspace_pr_status(
     exec::dispatch_blocking(
         move || {
             let path = Path::new(&workspace_path);
-            let head = current_workspace_head(&workspace_path).ok();
+            let head = read_workspace_head(&workspace_path).ok();
             let status = github::workspace_pull_request_status(path);
             let eligibility = if status.is_none() {
                 let is_github = github::is_github_workspace(path);

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -535,6 +535,7 @@ fn build_ui(app: &Application) {
         creating_pr_workspaces: RefCell::new(HashSet::new()),
         creating_session_workspaces: RefCell::new(HashSet::new()),
         closing_sessions: RefCell::new(HashSet::new()),
+        creating_workspaces: RefCell::new(HashSet::new()),
     });
 
     let sidebar_widgets = build_sidebar_widgets(&state);
@@ -572,6 +573,7 @@ pub struct AppState {
     pub(crate) creating_pr_workspaces: RefCell<HashSet<String>>,
     pub(crate) creating_session_workspaces: RefCell<HashSet<String>>,
     pub(crate) closing_sessions: RefCell<HashSet<String>>,
+    creating_workspaces: RefCell<HashSet<String>>,
 }
 
 #[derive(Clone)]
@@ -1513,8 +1515,8 @@ fn build_repo_row(
     {
         let state = state.clone();
         let repo_canonical = repo_canonical.to_string();
-        button.connect_clicked(move |_| {
-            create_and_edit_workspace(&state, &repo_canonical);
+        button.connect_clicked(move |button| {
+            create_and_edit_workspace(&state, &repo_canonical, button);
         });
     }
 
@@ -1605,8 +1607,8 @@ fn build_workspace_row(
     {
         let state = state.clone();
         let workspace = workspace.clone();
-        clone_button.connect_clicked(move |_| {
-            clone_and_edit_workspace(&state, &workspace);
+        clone_button.connect_clicked(move |button| {
+            clone_and_edit_workspace(&state, &workspace, button);
         });
     }
 
@@ -1757,58 +1759,88 @@ fn build_content(detail_container: GtkBox) -> GtkBox {
     content
 }
 
-fn create_and_edit_workspace(state: &Rc<AppState>, repo_canonical: &str) {
-    match create_workspace(repo_canonical, None) {
-        Ok(workspace) => {
-            let workspace_ref = workspace_ref(&workspace);
-            let selected_session = workspace.sessions.first().map(|session| session.id.clone());
-            let preferred_session = selected_session.clone();
-            let mut next_groups = current_groups(state);
-            if let Some(group) = next_groups
-                .iter_mut()
-                .find(|group| group.repo_canonical == workspace.repo_canonical)
-            {
-                group.workspaces.push(workspace);
-                group.workspace_count = group.workspaces.len();
-            }
-            *state.workspace_groups.borrow_mut() = next_groups.clone();
-            *state.selected_workspace.borrow_mut() = Some(workspace_ref.clone());
-            *state.editing_workspace.borrow_mut() = Some(workspace_ref.clone());
-            remember_selected_session(state, &workspace_ref, selected_session.as_deref());
-            schedule_render_current_ui(state, Some(workspace_ref), preferred_session);
-        }
-        Err(err) => {
-            eprintln!("failed to create workspace: {err}");
-        }
+fn create_and_edit_workspace(state: &Rc<AppState>, repo_canonical: &str, button: &Button) {
+    if !state
+        .creating_workspaces
+        .borrow_mut()
+        .insert(repo_canonical.to_string())
+    {
+        return;
     }
+    button.set_sensitive(false);
+
+    let state = state.clone();
+    let repo_canonical = repo_canonical.to_string();
+    let button = button.clone();
+    exec::dispatch(
+        create_workspace(repo_canonical.clone(), None),
+        move |result| {
+            state.creating_workspaces.borrow_mut().remove(&repo_canonical);
+            button.set_sensitive(true);
+            match result {
+                Ok(workspace) => {
+                    select_and_edit_new_workspace(&state, workspace);
+                }
+                Err(err) => {
+                    eprintln!("failed to create workspace: {err}");
+                }
+            }
+        },
+    );
 }
 
-fn clone_and_edit_workspace(state: &Rc<AppState>, workspace: &WorkspaceEntry) {
+fn clone_and_edit_workspace(state: &Rc<AppState>, workspace: &WorkspaceEntry, button: &Button) {
     let source_workspace_ref = workspace_ref(workspace);
-    match clone_workspace(&source_workspace_ref, &workspace.name) {
-        Ok(workspace) => {
-            let workspace_ref = workspace_ref(&workspace);
-            let selected_session = workspace.sessions.first().map(|session| session.id.clone());
-            let preferred_session = selected_session.clone();
-            let mut next_groups = current_groups(state);
-            if let Some(group) = next_groups
-                .iter_mut()
-                .find(|group| group.repo_canonical == workspace.repo_canonical)
-            {
-                group.workspaces.push(workspace);
-                group.workspace_count = group.workspaces.len();
-            }
-            *state.workspace_groups.borrow_mut() = next_groups.clone();
-            *state.selected_workspace.borrow_mut() = Some(workspace_ref.clone());
-            *state.editing_workspace.borrow_mut() = Some(workspace_ref.clone());
-            remember_selected_session(state, &workspace_ref, selected_session.as_deref());
-            schedule_render_current_ui(state, Some(workspace_ref), preferred_session);
-        }
-        Err(err) => {
-            eprintln!("failed to clone workspace: {err}");
-            schedule_render_current_ui(state, Some(source_workspace_ref), None);
-        }
+    if !state
+        .creating_workspaces
+        .borrow_mut()
+        .insert(source_workspace_ref.clone())
+    {
+        return;
     }
+    button.set_sensitive(false);
+
+    let state = state.clone();
+    let button = button.clone();
+    let source_name = workspace.name.clone();
+    exec::dispatch(
+        clone_workspace(source_workspace_ref.clone(), source_name),
+        move |result| {
+            state
+                .creating_workspaces
+                .borrow_mut()
+                .remove(&source_workspace_ref);
+            button.set_sensitive(true);
+            match result {
+                Ok(workspace) => {
+                    select_and_edit_new_workspace(&state, workspace);
+                }
+                Err(err) => {
+                    eprintln!("failed to clone workspace: {err}");
+                    schedule_render_current_ui(&state, Some(source_workspace_ref.clone()), None);
+                }
+            }
+        },
+    );
+}
+
+fn select_and_edit_new_workspace(state: &Rc<AppState>, workspace: WorkspaceEntry) {
+    let workspace_ref = workspace_ref(&workspace);
+    let selected_session = workspace.sessions.first().map(|session| session.id.clone());
+    let preferred_session = selected_session.clone();
+    let mut next_groups = current_groups(state);
+    if let Some(group) = next_groups
+        .iter_mut()
+        .find(|group| group.repo_canonical == workspace.repo_canonical)
+    {
+        group.workspaces.push(workspace);
+        group.workspace_count = group.workspaces.len();
+    }
+    *state.workspace_groups.borrow_mut() = next_groups.clone();
+    *state.selected_workspace.borrow_mut() = Some(workspace_ref.clone());
+    *state.editing_workspace.borrow_mut() = Some(workspace_ref.clone());
+    remember_selected_session(state, &workspace_ref, selected_session.as_deref());
+    schedule_render_current_ui(state, Some(workspace_ref), preferred_session);
 }
 
 fn sync_repo_and_refresh(state: &Rc<AppState>, repo_canonical: &str) {

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -19,9 +19,9 @@ use swarm::forges::github::{self, PullRequestStatus, PullRequestStatusState};
 
 use crate::{
     data::{
-        add_repository, clone_workspace, collapse_repository, create_workspace,
-        current_workspace_branch, current_workspace_head, expand_repository, load_workspace_groups,
-        remove_workspace, rename_workspace, sync_repository, workspace_head_path, WorkspaceEntry,
+        add_repository, clone_workspace, create_workspace, current_workspace_branch,
+        current_workspace_head, load_workspace_groups, remove_workspace, rename_workspace,
+        set_repository_collapsed, sync_repository, workspace_head_path, WorkspaceEntry,
         WorkspaceGroup,
     },
     exec,
@@ -536,6 +536,7 @@ fn build_ui(app: &Application) {
         creating_session_workspaces: RefCell::new(HashSet::new()),
         closing_sessions: RefCell::new(HashSet::new()),
         creating_workspaces: RefCell::new(HashSet::new()),
+        removing_workspaces: RefCell::new(HashSet::new()),
     });
 
     let sidebar_widgets = build_sidebar_widgets(&state);
@@ -574,6 +575,7 @@ pub struct AppState {
     pub(crate) creating_session_workspaces: RefCell<HashSet<String>>,
     pub(crate) closing_sessions: RefCell<HashSet<String>>,
     creating_workspaces: RefCell<HashSet<String>>,
+    removing_workspaces: RefCell<HashSet<String>>,
 }
 
 #[derive(Clone)]
@@ -1628,8 +1630,8 @@ fn build_workspace_row(
     {
         let state = state.clone();
         let workspace = workspace.clone();
-        delete_button.connect_clicked(move |_| {
-            remove_selected_workspace(&state, &workspace);
+        delete_button.connect_clicked(move |button| {
+            remove_selected_workspace(&state, &workspace, button);
         });
     }
 
@@ -1875,32 +1877,31 @@ fn sync_repo_and_refresh(state: &Rc<AppState>, repo_canonical: &str) {
 }
 
 fn toggle_repo_collapsed_and_refresh(state: &Rc<AppState>, repo_canonical: &str, collapsed: bool) {
-    let result = if collapsed {
-        expand_repository(repo_canonical)
-    } else {
-        collapse_repository(repo_canonical)
-    };
-
-    match result {
-        Ok(()) => {
-            let mut next_groups = current_groups(state);
-            if let Some(group) = next_groups
-                .iter_mut()
-                .find(|group| group.repo_canonical == repo_canonical)
-            {
-                group.collapsed = !collapsed;
+    let state = state.clone();
+    let repo_canonical = repo_canonical.to_string();
+    exec::dispatch(
+        set_repository_collapsed(repo_canonical.clone(), !collapsed),
+        move |result| match result {
+            Ok(()) => {
+                let mut next_groups = current_groups(&state);
+                if let Some(group) = next_groups
+                    .iter_mut()
+                    .find(|group| group.repo_canonical == repo_canonical)
+                {
+                    group.collapsed = !collapsed;
+                }
+                *state.workspace_groups.borrow_mut() = next_groups.clone();
+                *state.editing_workspace.borrow_mut() = None;
+                *state.selected_session.borrow_mut() = None;
+                schedule_render_current_ui(&state, None, None);
             }
-            *state.workspace_groups.borrow_mut() = next_groups.clone();
-            *state.editing_workspace.borrow_mut() = None;
-            *state.selected_session.borrow_mut() = None;
-            schedule_render_current_ui(state, None, None);
-        }
-        Err(err) => {
-            eprintln!("failed to toggle repository collapse: {err}");
-            let preferred_workspace = state.selected_workspace.borrow().clone();
-            schedule_render_current_ui(state, preferred_workspace, None);
-        }
-    }
+            Err(err) => {
+                eprintln!("failed to toggle repository collapse: {err}");
+                let preferred_workspace = state.selected_workspace.borrow().clone();
+                schedule_render_current_ui(&state, preferred_workspace, None);
+            }
+        },
+    );
 }
 
 fn sidebar_append_static_row<W: IsA<Widget>>(list: &ListBox, widget: &W) {
@@ -1967,7 +1968,7 @@ fn install_workspace_rename_handlers(
 }
 
 fn commit_workspace_rename(state: &Rc<AppState>, current_workspace_ref: &str, next_name: &str) {
-    let next_name = next_name.trim();
+    let next_name = next_name.trim().to_string();
     *state.editing_workspace.borrow_mut() = None;
 
     if next_name.is_empty() {
@@ -1975,88 +1976,115 @@ fn commit_workspace_rename(state: &Rc<AppState>, current_workspace_ref: &str, ne
         return;
     }
 
-    match rename_workspace(current_workspace_ref, next_name) {
-        Ok(workspace) => {
-            let next_workspace_ref = workspace_ref(&workspace);
-            clear_workspace_pr_status(state, current_workspace_ref);
-            let mut next_groups = current_groups(state);
-            for group in &mut next_groups {
-                if group.repo_canonical != workspace.repo_canonical {
-                    continue;
+    let state = state.clone();
+    let current_workspace_ref = current_workspace_ref.to_string();
+    exec::dispatch(
+        rename_workspace(current_workspace_ref.clone(), next_name),
+        move |result| match result {
+            Ok(workspace) => {
+                let next_workspace_ref = workspace_ref(&workspace);
+                clear_workspace_pr_status(&state, &current_workspace_ref);
+                let mut next_groups = current_groups(&state);
+                for group in &mut next_groups {
+                    if group.repo_canonical != workspace.repo_canonical {
+                        continue;
+                    }
+                    if let Some(candidate) = group
+                        .workspaces
+                        .iter_mut()
+                        .find(|candidate| workspace_ref(candidate) == current_workspace_ref)
+                    {
+                        *candidate = workspace;
+                        break;
+                    }
                 }
-                if let Some(candidate) = group
-                    .workspaces
-                    .iter_mut()
-                    .find(|candidate| workspace_ref(candidate) == current_workspace_ref)
-                {
-                    *candidate = workspace;
-                    break;
-                }
+                *state.workspace_groups.borrow_mut() = next_groups.clone();
+                *state.selected_workspace.borrow_mut() = Some(next_workspace_ref.clone());
+                let remembered_session = state
+                    .selected_sessions
+                    .borrow_mut()
+                    .remove(&current_workspace_ref);
+                remember_selected_session(&state, &next_workspace_ref, remembered_session.as_deref());
+                schedule_render_current_ui(&state, Some(next_workspace_ref), None);
             }
-            *state.workspace_groups.borrow_mut() = next_groups.clone();
-            *state.selected_workspace.borrow_mut() = Some(next_workspace_ref.clone());
-            let remembered_session = state
-                .selected_sessions
-                .borrow_mut()
-                .remove(current_workspace_ref);
-            remember_selected_session(state, &next_workspace_ref, remembered_session.as_deref());
-            schedule_render_current_ui(state, Some(next_workspace_ref), None);
-        }
-        Err(err) => {
-            eprintln!("failed to rename workspace: {err}");
-            *state.editing_workspace.borrow_mut() = Some(current_workspace_ref.to_string());
-            schedule_render_current_ui(state, Some(current_workspace_ref.to_string()), None);
-        }
-    }
+            Err(err) => {
+                eprintln!("failed to rename workspace: {err}");
+                *state.editing_workspace.borrow_mut() = Some(current_workspace_ref.clone());
+                schedule_render_current_ui(&state, Some(current_workspace_ref.clone()), None);
+            }
+        },
+    );
 }
 
-fn remove_selected_workspace(state: &Rc<AppState>, workspace: &WorkspaceEntry) {
+fn remove_selected_workspace(state: &Rc<AppState>, workspace: &WorkspaceEntry, button: &Button) {
     let removed_workspace_ref = workspace_ref(workspace);
-    match remove_workspace(&removed_workspace_ref) {
-        Ok(_) => {
-            // Drop the cached terminals of the removed sessions, otherwise their
-            // widgets stay alive and keep polling a socket that is already gone.
-            if let Some(detail_widgets) = state.detail_widgets.borrow().as_ref() {
-                detail_widgets.evict_terminals(
-                    workspace
-                        .sessions
-                        .iter()
-                        .map(|session| session.id.as_str()),
-                );
-            }
-            clear_workspace_pr_status(state, &removed_workspace_ref);
-            let mut next_groups = state.workspace_groups.borrow().clone();
-            for group in &mut next_groups {
-                group
-                    .workspaces
-                    .retain(|candidate| workspace_ref(candidate) != removed_workspace_ref);
-                group.workspace_count = group.workspaces.len();
-            }
+    if !state
+        .removing_workspaces
+        .borrow_mut()
+        .insert(removed_workspace_ref.clone())
+    {
+        return;
+    }
+    button.set_sensitive(false);
 
-            let next_workspace = state
-                .selected_workspace
-                .borrow()
-                .clone()
-                .filter(|selected| selected != &removed_workspace_ref)
-                .or_else(|| {
-                    first_workspace(&next_groups).map(|workspace| workspace_ref(&workspace))
-                });
-
-            *state.workspace_groups.borrow_mut() = next_groups.clone();
-            *state.selected_workspace.borrow_mut() = next_workspace.clone();
-            *state.editing_workspace.borrow_mut() = None;
+    let state = state.clone();
+    let button = button.clone();
+    let workspace = workspace.clone();
+    exec::dispatch(
+        remove_workspace(removed_workspace_ref.clone()),
+        move |result| {
             state
-                .selected_sessions
+                .removing_workspaces
                 .borrow_mut()
                 .remove(&removed_workspace_ref);
-            *state.selected_session.borrow_mut() = None;
-            schedule_render_current_ui(state, next_workspace, None);
-        }
-        Err(err) => {
-            eprintln!("failed to remove workspace: {err}");
-            schedule_refresh(state, Some(removed_workspace_ref), None);
-        }
-    }
+            button.set_sensitive(true);
+            match result {
+                Ok(_) => {
+                    // Drop the cached terminals of the removed sessions, otherwise their
+                    // widgets stay alive and keep polling a socket that is already gone.
+                    if let Some(detail_widgets) = state.detail_widgets.borrow().as_ref() {
+                        detail_widgets.evict_terminals(
+                            workspace
+                                .sessions
+                                .iter()
+                                .map(|session| session.id.as_str()),
+                        );
+                    }
+                    clear_workspace_pr_status(&state, &removed_workspace_ref);
+                    let mut next_groups = state.workspace_groups.borrow().clone();
+                    for group in &mut next_groups {
+                        group
+                            .workspaces
+                            .retain(|candidate| workspace_ref(candidate) != removed_workspace_ref);
+                        group.workspace_count = group.workspaces.len();
+                    }
+
+                    let next_workspace = state
+                        .selected_workspace
+                        .borrow()
+                        .clone()
+                        .filter(|selected| selected != &removed_workspace_ref)
+                        .or_else(|| {
+                            first_workspace(&next_groups).map(|workspace| workspace_ref(&workspace))
+                        });
+
+                    *state.workspace_groups.borrow_mut() = next_groups.clone();
+                    *state.selected_workspace.borrow_mut() = next_workspace.clone();
+                    *state.editing_workspace.borrow_mut() = None;
+                    state
+                        .selected_sessions
+                        .borrow_mut()
+                        .remove(&removed_workspace_ref);
+                    *state.selected_session.borrow_mut() = None;
+                    schedule_render_current_ui(&state, next_workspace, None);
+                }
+                Err(err) => {
+                    eprintln!("failed to remove workspace: {err}");
+                    schedule_refresh(&state, Some(removed_workspace_ref.clone()), None);
+                }
+            }
+        },
+    );
 }
 
 fn submit_repository_form(state: &Rc<AppState>, repository_entry: &Entry, alias_entry: &Entry) {
@@ -2076,20 +2104,24 @@ fn submit_repository_form(state: &Rc<AppState>, repository_entry: &Entry, alias_
         form.error = None;
     }
 
-    let alias = (!alias_text.is_empty()).then_some(alias_text.as_str());
+    let alias = (!alias_text.is_empty()).then_some(alias_text.clone());
     let preferred_workspace = state.selected_workspace.borrow().clone();
 
-    match add_repository(&repository, alias) {
-        Ok(_) => {
-            *state.repository_form.borrow_mut() = RepositoryFormState::default();
-            schedule_refresh(state, preferred_workspace, None);
-        }
-        Err(err) => {
-            state.repository_form.borrow_mut().error = Some(err.to_string());
-            sync_repository_form_widgets(state, false);
-            focus_repository_form_field(state);
-        }
-    }
+    let state = state.clone();
+    exec::dispatch(
+        add_repository(repository, alias),
+        move |result| match result {
+            Ok(_) => {
+                *state.repository_form.borrow_mut() = RepositoryFormState::default();
+                schedule_refresh(&state, preferred_workspace, None);
+            }
+            Err(err) => {
+                state.repository_form.borrow_mut().error = Some(err.to_string());
+                sync_repository_form_widgets(&state, false);
+                focus_repository_form_field(&state);
+            }
+        },
+    );
 }
 
 struct WorkspaceRow {

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -1,12 +1,11 @@
 use gtk::{
-    gdk,
+    Align, Application, ApplicationWindow, Box as GtkBox, Button, CssProvider, Entry,
+    EventControllerKey, EventControllerMotion, Grid, Image, Label, ListBox, ListBoxRow,
+    Orientation, PolicyType, PropagationPhase, STYLE_PROVIDER_PRIORITY_APPLICATION, ScrolledWindow,
+    SelectionMode, Spinner, Widget, gdk,
     gio::{self, FileMonitor, FileMonitorFlags},
     glib,
     prelude::*,
-    Align, Application, ApplicationWindow, Box as GtkBox, Button, CssProvider, Entry,
-    EventControllerKey, EventControllerMotion, Grid, Image, Label, ListBox, ListBoxRow,
-    Orientation, PolicyType, PropagationPhase, ScrolledWindow, SelectionMode, Spinner, Widget,
-    STYLE_PROVIDER_PRIORITY_APPLICATION,
 };
 use std::{
     cell::{Cell, RefCell},
@@ -19,10 +18,9 @@ use swarm::forges::github::{self, PullRequestStatus, PullRequestStatusState};
 
 use crate::{
     data::{
-        add_repository, clone_workspace, create_workspace, current_workspace_branch,
-        load_workspace_groups, read_workspace_head, remove_workspace, rename_workspace,
-        set_repository_collapsed, sync_repository, workspace_head_path, WorkspaceEntry,
-        WorkspaceGroup,
+        WorkspaceEntry, WorkspaceGroup, add_repository, clone_workspace, create_workspace,
+        current_workspace_branch, load_workspace_groups, read_workspace_head, remove_workspace,
+        rename_workspace, set_repository_collapsed, sync_repository, workspace_head_path,
     },
     exec,
     workspace_panel::DetailWidgets,
@@ -973,8 +971,7 @@ fn apply_workspace_pr_update(
     eligibility: CreatePrEligibility,
 ) {
     let selected_workspace = state.selected_workspace.borrow().clone();
-    let selected_workspace_changed =
-        selected_workspace.as_deref() == Some(workspace_ref.as_str());
+    let selected_workspace_changed = selected_workspace.as_deref() == Some(workspace_ref.as_str());
     state.pending_pr_lookups.borrow_mut().remove(&workspace_ref);
     state.pr_statuses.borrow_mut().insert(
         workspace_ref,
@@ -1756,17 +1753,25 @@ fn install_branch_monitor(state: &Rc<AppState>, workspace: &WorkspaceEntry, bran
     let monitor_state = state.clone();
     let workspace_ref = workspace_ref(workspace);
     let workspace_path = workspace.path.clone();
-    monitor.connect_changed(
-        move |_, _, _, _| match current_workspace_branch(&workspace_path) {
-            Ok(branch) => {
-                clear_workspace_pr_status(&monitor_state, &workspace_ref);
-                update_cached_workspace_branch(&monitor_state, &workspace_ref, &branch);
-                label.set_text(&branch);
-                schedule_background_sidebar_refresh(&monitor_state);
-            }
-            Err(err) => eprintln!("failed to refresh branch for {workspace_path}: {err}"),
-        },
-    );
+    monitor.connect_changed(move |_, _, _, _| {
+        let state = monitor_state.clone();
+        let workspace_ref = workspace_ref.clone();
+        let label = label.clone();
+        let workspace_path = workspace_path.clone();
+        let read_path = workspace_path.clone();
+        exec::dispatch_blocking(
+            move || current_workspace_branch(&read_path),
+            move |result| match result {
+                Ok(branch) => {
+                    clear_workspace_pr_status(&state, &workspace_ref);
+                    update_cached_workspace_branch(&state, &workspace_ref, &branch);
+                    label.set_text(&branch);
+                    schedule_background_sidebar_refresh(&state);
+                }
+                Err(err) => eprintln!("failed to refresh branch for {workspace_path}: {err}"),
+            },
+        );
+    });
 
     state.branch_monitors.borrow_mut().push(monitor);
 }
@@ -1800,7 +1805,10 @@ fn create_and_edit_workspace(state: &Rc<AppState>, repo_canonical: &str, button:
     exec::dispatch(
         create_workspace(repo_canonical.clone(), None),
         move |result| {
-            state.creating_workspaces.borrow_mut().remove(&repo_canonical);
+            state
+                .creating_workspaces
+                .borrow_mut()
+                .remove(&repo_canonical);
             button.set_sensitive(true);
             match result {
                 Ok(workspace) => {
@@ -2027,7 +2035,11 @@ fn commit_workspace_rename(state: &Rc<AppState>, current_workspace_ref: &str, ne
                     .selected_sessions
                     .borrow_mut()
                     .remove(&current_workspace_ref);
-                remember_selected_session(&state, &next_workspace_ref, remembered_session.as_deref());
+                remember_selected_session(
+                    &state,
+                    &next_workspace_ref,
+                    remembered_session.as_deref(),
+                );
                 schedule_render_current_ui(&state, Some(next_workspace_ref), None);
             }
             Err(err) => {
@@ -2067,10 +2079,7 @@ fn remove_selected_workspace(state: &Rc<AppState>, workspace: &WorkspaceEntry, b
                     // widgets stay alive and keep polling a socket that is already gone.
                     if let Some(detail_widgets) = state.detail_widgets.borrow().as_ref() {
                         detail_widgets.evict_terminals(
-                            workspace
-                                .sessions
-                                .iter()
-                                .map(|session| session.id.as_str()),
+                            workspace.sessions.iter().map(|session| session.id.as_str()),
                         );
                     }
                     clear_workspace_pr_status(&state, &removed_workspace_ref);

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -13,7 +13,6 @@ use std::{
     collections::{HashMap, HashSet},
     path::Path,
     rc::Rc,
-    sync::mpsc,
     time::{Duration, Instant},
 };
 use swarm::forges::github::{self, PullRequestStatus, PullRequestStatusState};
@@ -519,7 +518,6 @@ fn build_ui(app: &Application) {
     let content_host = GtkBox::new(Orientation::Vertical, 0);
     content_host.set_hexpand(true);
     content_host.set_vexpand(true);
-    let (pr_status_sender, pr_status_receiver) = mpsc::channel();
 
     let state = Rc::new(AppState {
         sidebar_widgets: RefCell::new(None),
@@ -534,8 +532,6 @@ fn build_ui(app: &Application) {
         syncing_repositories: RefCell::new(HashSet::new()),
         pr_statuses: RefCell::new(HashMap::new()),
         pending_pr_lookups: RefCell::new(HashSet::new()),
-        pr_status_sender,
-        pr_status_receiver: RefCell::new(pr_status_receiver),
         creating_pr_workspaces: RefCell::new(HashSet::new()),
     });
 
@@ -552,7 +548,6 @@ fn build_ui(app: &Application) {
     window.set_child(Some(&shell));
 
     install_session_cycle_shortcuts(&window, &state);
-    install_pr_status_pump(&state);
     install_pr_status_scheduler(&state);
     refresh_ui(&state, None, None);
 
@@ -572,8 +567,6 @@ pub struct AppState {
     syncing_repositories: RefCell<HashSet<String>>,
     pr_statuses: RefCell<HashMap<String, CachedPrStatus>>,
     pending_pr_lookups: RefCell<HashSet<String>>,
-    pr_status_sender: mpsc::Sender<WorkspacePrUpdate>,
-    pr_status_receiver: RefCell<mpsc::Receiver<WorkspacePrUpdate>>,
     pub(crate) creating_pr_workspaces: RefCell<HashSet<String>>,
 }
 
@@ -649,12 +642,6 @@ pub enum WorkspacePrState {
     Loading,
     None,
     Ready(PullRequestStatus),
-}
-
-struct WorkspacePrUpdate {
-    workspace_ref: String,
-    status: Option<PullRequestStatus>,
-    head: Option<String>,
 }
 
 fn refresh_ui(
@@ -787,51 +774,6 @@ pub fn schedule_render_current_ui(
     let state = state.clone();
     glib::idle_add_local_once(move || {
         render_current_ui(&state, preferred_workspace, preferred_session);
-    });
-}
-
-fn install_pr_status_pump(state: &Rc<AppState>) {
-    let state = state.clone();
-    glib::timeout_add_local(Duration::from_millis(50), move || {
-        let mut changed = false;
-        let mut selected_workspace_changed = false;
-        let selected_workspace = state.selected_workspace.borrow().clone();
-        {
-            let receiver = state.pr_status_receiver.borrow_mut();
-            while let Ok(update) = receiver.try_recv() {
-                if selected_workspace.as_deref() == Some(update.workspace_ref.as_str()) {
-                    selected_workspace_changed = true;
-                }
-                state
-                    .pending_pr_lookups
-                    .borrow_mut()
-                    .remove(&update.workspace_ref);
-                state.pr_statuses.borrow_mut().insert(
-                    update.workspace_ref,
-                    CachedPrStatus {
-                        state: update
-                            .status
-                            .map(WorkspacePrState::Ready)
-                            .unwrap_or(WorkspacePrState::None),
-                        fetched_at: Instant::now(),
-                        head: update.head,
-                    },
-                );
-                changed = true;
-            }
-        }
-
-        if changed {
-            if selected_workspace_changed {
-                if let Some(selected_workspace) = selected_workspace.as_deref() {
-                    render_selected_workspace_detail(&state, selected_workspace, None);
-                }
-            } else if !state.repository_form.borrow().expanded {
-                render_sidebar_only(&state);
-            }
-        }
-
-        glib::ControlFlow::Continue
     });
 }
 
@@ -979,17 +921,48 @@ pub(crate) fn request_workspace_pr_status(
         );
     }
 
-    let sender = state.pr_status_sender.clone();
     let workspace_path = workspace.path.clone();
-    std::thread::spawn(move || {
-        let head = current_workspace_head(&workspace_path).ok();
-        let status = github::workspace_pull_request_status(Path::new(&workspace_path));
-        let _ = sender.send(WorkspacePrUpdate {
-            workspace_ref: workspace_id,
-            status,
+    let state = state.clone();
+    exec::dispatch_blocking(
+        move || {
+            let head = current_workspace_head(&workspace_path).ok();
+            let status = github::workspace_pull_request_status(Path::new(&workspace_path));
+            (status, head)
+        },
+        move |(status, head)| {
+            apply_workspace_pr_update(&state, workspace_id, status, head);
+        },
+    );
+}
+
+fn apply_workspace_pr_update(
+    state: &Rc<AppState>,
+    workspace_ref: String,
+    status: Option<PullRequestStatus>,
+    head: Option<String>,
+) {
+    let selected_workspace = state.selected_workspace.borrow().clone();
+    let selected_workspace_changed =
+        selected_workspace.as_deref() == Some(workspace_ref.as_str());
+    state.pending_pr_lookups.borrow_mut().remove(&workspace_ref);
+    state.pr_statuses.borrow_mut().insert(
+        workspace_ref,
+        CachedPrStatus {
+            state: status
+                .map(WorkspacePrState::Ready)
+                .unwrap_or(WorkspacePrState::None),
+            fetched_at: Instant::now(),
             head,
-        });
-    });
+        },
+    );
+
+    if selected_workspace_changed {
+        if let Some(selected_workspace) = selected_workspace.as_deref() {
+            render_selected_workspace_detail(state, selected_workspace, None);
+        }
+    } else if !state.repository_form.borrow().expanded {
+        render_sidebar_only(state);
+    }
 }
 
 pub(crate) fn clear_workspace_pr_status(state: &Rc<AppState>, workspace_ref: &str) {

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -533,6 +533,7 @@ fn build_ui(app: &Application) {
         pr_statuses: RefCell::new(HashMap::new()),
         pending_pr_lookups: RefCell::new(HashSet::new()),
         creating_pr_workspaces: RefCell::new(HashSet::new()),
+        creating_session_workspaces: RefCell::new(HashSet::new()),
     });
 
     let sidebar_widgets = build_sidebar_widgets(&state);
@@ -568,6 +569,7 @@ pub struct AppState {
     pr_statuses: RefCell<HashMap<String, CachedPrStatus>>,
     pending_pr_lookups: RefCell<HashSet<String>>,
     pub(crate) creating_pr_workspaces: RefCell<HashSet<String>>,
+    pub(crate) creating_session_workspaces: RefCell<HashSet<String>>,
 }
 
 #[derive(Clone)]

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -657,15 +657,18 @@ fn refresh_ui(
     preferred_workspace: Option<String>,
     preferred_session: Option<String>,
 ) {
-    let groups = match load_workspace_groups() {
-        Ok(groups) => groups,
-        Err(err) => {
-            eprintln!("failed to load workspaces: {err}");
-            return;
-        }
-    };
-    *state.workspace_groups.borrow_mut() = groups.clone();
-    render_ui(state, &groups, preferred_workspace, preferred_session);
+    let state = state.clone();
+    exec::dispatch(load_workspace_groups(), move |result| {
+        let groups = match result {
+            Ok(groups) => groups,
+            Err(err) => {
+                eprintln!("failed to load workspaces: {err}");
+                return;
+            }
+        };
+        *state.workspace_groups.borrow_mut() = groups.clone();
+        render_ui(&state, &groups, preferred_workspace, preferred_session);
+    });
 }
 
 fn render_ui(
@@ -704,10 +707,9 @@ fn schedule_refresh(
     preferred_workspace: Option<String>,
     preferred_session: Option<String>,
 ) {
-    let state = state.clone();
-    glib::idle_add_local_once(move || {
-        refresh_ui(&state, preferred_workspace, preferred_session);
-    });
+    // refresh_ui already defers: the load runs on the shared runtime and the
+    // apply lands on a later main-loop iteration, so no idle hop is needed.
+    refresh_ui(state, preferred_workspace, preferred_session);
 }
 
 pub fn current_groups(state: &Rc<AppState>) -> Vec<WorkspaceGroup> {

--- a/ui/app.rs
+++ b/ui/app.rs
@@ -25,6 +25,7 @@ use crate::{
         remove_workspace, rename_workspace, sync_repository, workspace_head_path, WorkspaceEntry,
         WorkspaceGroup,
     },
+    exec,
     workspace_panel::DetailWidgets,
 };
 
@@ -1851,55 +1852,16 @@ fn sync_repo_and_refresh(state: &Rc<AppState>, repo_canonical: &str) {
         preferred_session.clone(),
     );
 
-    let (sender, receiver) = mpsc::channel();
-    {
-        let repo_canonical = repo_canonical.clone();
-        std::thread::spawn(move || {
-            let _ = sender.send(sync_repository(&repo_canonical));
-        });
-    }
-
     let state = state.clone();
-    glib::timeout_add_local(Duration::from_millis(50), move || {
-        match receiver.try_recv() {
-            Ok(result) => {
-                state
-                    .syncing_repositories
-                    .borrow_mut()
-                    .remove(&repo_canonical);
-                match result {
-                    Ok(()) => {
-                        schedule_refresh(
-                            &state,
-                            preferred_workspace.clone(),
-                            preferred_session.clone(),
-                        );
-                    }
-                    Err(err) => {
-                        eprintln!("failed to sync repository: {err}");
-                        schedule_refresh(
-                            &state,
-                            preferred_workspace.clone(),
-                            preferred_session.clone(),
-                        );
-                    }
-                }
-                glib::ControlFlow::Break
-            }
-            Err(mpsc::TryRecvError::Empty) => glib::ControlFlow::Continue,
-            Err(mpsc::TryRecvError::Disconnected) => {
-                state
-                    .syncing_repositories
-                    .borrow_mut()
-                    .remove(&repo_canonical);
-                schedule_refresh(
-                    &state,
-                    preferred_workspace.clone(),
-                    preferred_session.clone(),
-                );
-                glib::ControlFlow::Break
-            }
+    exec::dispatch(sync_repository(repo_canonical.clone()), move |result| {
+        state
+            .syncing_repositories
+            .borrow_mut()
+            .remove(&repo_canonical);
+        if let Err(err) = result {
+            eprintln!("failed to sync repository: {err}");
         }
+        schedule_refresh(&state, preferred_workspace, preferred_session);
     });
 }
 

--- a/ui/data.rs
+++ b/ui/data.rs
@@ -4,7 +4,6 @@ use std::{
     process::Command,
     time::{Duration, SystemTime},
 };
-use crate::exec;
 use swarm::{
     SwarmError,
     repos::{Repository, RepositoryStore},
@@ -41,59 +40,53 @@ pub struct SessionEntry {
     pub socket_path: String,
 }
 
-pub fn load_workspace_groups() -> Result<Vec<WorkspaceGroup>, SwarmError> {
-    exec::runtime().block_on(async {
-        let repo_store = RepositoryStore::open().await?;
-        let workspace_store = WorkspaceStore::open().await?;
-        let session_store = SessionStore::open().await?;
-        let repos = repo_store.list().await?;
-        let mut groups = Vec::with_capacity(repos.len());
+pub async fn load_workspace_groups() -> Result<Vec<WorkspaceGroup>, SwarmError> {
+    let repo_store = RepositoryStore::open().await?;
+    let workspace_store = WorkspaceStore::open().await?;
+    let session_store = SessionStore::open().await?;
+    let repos = repo_store.list().await?;
+    let mut groups = Vec::with_capacity(repos.len());
 
-        for repo in repos {
-            let repo_label = repo.alias.clone().unwrap_or_else(|| repo.name.clone());
-            let repo_canonical = repo.canonical();
-            let repo_status = repo_sync_status(&repo_store, &repo);
-            let workspaces = workspace_store.list(&repo_canonical).await?;
-            let workspaces = workspaces.into_iter().map(|workspace| async {
-                let workspace_ref = format!("{}:{}", workspace.repository, workspace.name);
-                let sessions = session_store
-                    .list(Some(&workspace_ref))
-                    .await?
-                    .into_iter()
-                    .map(|session| SessionEntry {
-                        pid: session.pid,
-                        program: session_program(session.pid, &session.command),
-                        id: session.id,
-                        status: session.status,
-                        log_path: session.log_path.display().to_string(),
-                        socket_path: session.socket_path.display().to_string(),
-                    })
-                    .collect::<Vec<_>>();
+    for repo in repos {
+        let repo_label = repo.alias.clone().unwrap_or_else(|| repo.name.clone());
+        let repo_canonical = repo.canonical();
+        let repo_status = repo_sync_status(&repo_store, &repo);
+        let workspaces = workspace_store.list(&repo_canonical).await?;
+        let workspaces = workspaces.into_iter().map(|workspace| async {
+            let workspace_ref = format!("{}:{}", workspace.repository, workspace.name);
+            let sessions = session_store
+                .list(Some(&workspace_ref))
+                .await?
+                .into_iter()
+                .map(|session| SessionEntry {
+                    pid: session.pid,
+                    program: session_program(session.pid, &session.command),
+                    id: session.id,
+                    status: session.status,
+                    log_path: session.log_path.display().to_string(),
+                    socket_path: session.socket_path.display().to_string(),
+                })
+                .collect::<Vec<_>>();
 
-                Ok::<WorkspaceEntry, SwarmError>(map_workspace(
-                    &repo_canonical,
-                    workspace,
-                    sessions,
-                ))
-            });
-            let mut workspace_entries = Vec::new();
-            for workspace in workspaces {
-                workspace_entries.push(workspace.await?);
-            }
-            let workspace_count = workspace_entries.len();
-
-            groups.push(WorkspaceGroup {
-                repo_label,
-                repo_canonical,
-                repo_status,
-                collapsed: repo.collapsed,
-                workspace_count,
-                workspaces: workspace_entries,
-            });
+            Ok::<WorkspaceEntry, SwarmError>(map_workspace(&repo_canonical, workspace, sessions))
+        });
+        let mut workspace_entries = Vec::new();
+        for workspace in workspaces {
+            workspace_entries.push(workspace.await?);
         }
+        let workspace_count = workspace_entries.len();
 
-        Ok(groups)
-    })
+        groups.push(WorkspaceGroup {
+            repo_label,
+            repo_canonical,
+            repo_status,
+            collapsed: repo.collapsed,
+            workspace_count,
+            workspaces: workspace_entries,
+        });
+    }
+
+    Ok(groups)
 }
 
 pub async fn create_workspace(

--- a/ui/data.rs
+++ b/ui/data.rs
@@ -4,6 +4,7 @@ use std::{
     process::Command,
     time::{Duration, SystemTime},
 };
+use crate::exec;
 use swarm::{
     SwarmError,
     repos::{Repository, RepositoryStore},
@@ -41,8 +42,7 @@ pub struct SessionEntry {
 }
 
 pub fn load_workspace_groups() -> Result<Vec<WorkspaceGroup>, SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let repo_store = RepositoryStore::open().await?;
         let workspace_store = WorkspaceStore::open().await?;
         let session_store = SessionStore::open().await?;
@@ -100,8 +100,7 @@ pub fn create_workspace(
     repository: &str,
     name: Option<&str>,
 ) -> Result<WorkspaceEntry, SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let repo_store = RepositoryStore::open().await?;
         let workspace_store = WorkspaceStore::open().await?;
         let session_store = SessionStore::open().await?;
@@ -137,16 +136,14 @@ pub fn create_workspace(
 }
 
 pub fn add_repository(repository: &str, alias: Option<&str>) -> Result<Repository, SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let repo_store = RepositoryStore::open().await?;
         repo_store.add(repository, alias).await
     })
 }
 
 pub fn sync_repository(repository: &str) -> Result<(), SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let repo_store = RepositoryStore::open().await?;
         repo_store.sync(repository).await?;
         Ok(())
@@ -154,8 +151,7 @@ pub fn sync_repository(repository: &str) -> Result<(), SwarmError> {
 }
 
 pub fn collapse_repository(repository: &str) -> Result<(), SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let repo_store = RepositoryStore::open().await?;
         repo_store.collapse(repository).await?;
         Ok(())
@@ -163,8 +159,7 @@ pub fn collapse_repository(repository: &str) -> Result<(), SwarmError> {
 }
 
 pub fn expand_repository(repository: &str) -> Result<(), SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let repo_store = RepositoryStore::open().await?;
         repo_store.expand(repository).await?;
         Ok(())
@@ -172,8 +167,7 @@ pub fn expand_repository(repository: &str) -> Result<(), SwarmError> {
 }
 
 pub fn rename_workspace(workspace_ref: &str, name: &str) -> Result<WorkspaceEntry, SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let repo_store = RepositoryStore::open().await?;
         let workspace_store = WorkspaceStore::open().await?;
         let session_store = SessionStore::open().await?;
@@ -202,8 +196,7 @@ pub fn rename_workspace(workspace_ref: &str, name: &str) -> Result<WorkspaceEntr
 }
 
 pub fn clone_workspace(workspace_ref: &str, name: &str) -> Result<WorkspaceEntry, SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let repo_store = RepositoryStore::open().await?;
         let workspace_store = WorkspaceStore::open().await?;
         let session_store = SessionStore::open().await?;
@@ -238,8 +231,7 @@ pub fn clone_workspace(workspace_ref: &str, name: &str) -> Result<WorkspaceEntry
 }
 
 pub fn remove_workspace(workspace_ref: &str) -> Result<WorkspaceEntry, SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let repo_store = RepositoryStore::open().await?;
         let session_store = SessionStore::open().await?;
         let workspace_store = WorkspaceStore::open().await?;
@@ -261,8 +253,7 @@ pub fn remove_workspace(workspace_ref: &str) -> Result<WorkspaceEntry, SwarmErro
 }
 
 pub fn create_session(workspace_ref: &str) -> Result<SessionEntry, SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let session_store = SessionStore::open().await?;
         let session = session_store
             .create(workspace_ref, &default_session_command())
@@ -280,8 +271,7 @@ pub fn create_session(workspace_ref: &str) -> Result<SessionEntry, SwarmError> {
 }
 
 pub fn close_session(session_id: &str) -> Result<SessionEntry, SwarmError> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
+    exec::runtime().block_on(async {
         let session_store = SessionStore::open().await?;
         session_store.stop(session_id).await?;
         let session = session_store.remove(session_id).await?;

--- a/ui/data.rs
+++ b/ui/data.rs
@@ -250,21 +250,19 @@ pub fn remove_workspace(workspace_ref: &str) -> Result<WorkspaceEntry, SwarmErro
     })
 }
 
-pub fn create_session(workspace_ref: &str) -> Result<SessionEntry, SwarmError> {
-    exec::runtime().block_on(async {
-        let session_store = SessionStore::open().await?;
-        let session = session_store
-            .create(workspace_ref, &default_session_command())
-            .await?;
+pub async fn create_session(workspace_ref: String) -> Result<SessionEntry, SwarmError> {
+    let session_store = SessionStore::open().await?;
+    let session = session_store
+        .create(&workspace_ref, &default_session_command())
+        .await?;
 
-        Ok(SessionEntry {
-            id: session.id,
-            pid: session.pid,
-            program: session_program(session.pid, &session.command),
-            status: session.status,
-            log_path: session.log_path.display().to_string(),
-            socket_path: session.socket_path.display().to_string(),
-        })
+    Ok(SessionEntry {
+        id: session.id,
+        pid: session.pid,
+        program: session_program(session.pid, &session.command),
+        status: session.status,
+        log_path: session.log_path.display().to_string(),
+        socket_path: session.socket_path.display().to_string(),
     })
 }
 

--- a/ui/data.rs
+++ b/ui/data.rs
@@ -280,8 +280,55 @@ pub fn current_workspace_branch(path: &str) -> Result<String, SwarmError> {
     run_git(path, ["rev-parse", "--short", "HEAD"])
 }
 
-pub fn current_workspace_head(path: &str) -> Result<String, SwarmError> {
-    run_git(Path::new(path), ["rev-parse", "HEAD"])
+/// Resolves the workspace's HEAD commit by reading git's files directly, so
+/// callers on the GTK main thread never pay for a subprocess. Handles detached
+/// HEAD, loose refs, packed refs, and linked worktrees (`commondir`).
+pub fn read_workspace_head(path: &str) -> Result<String, SwarmError> {
+    let head_path = workspace_head_path(path)?;
+    let git_dir = head_path
+        .parent()
+        .ok_or_else(|| SwarmError::Git(format!("no git dir for {path}")))?;
+    let head = fs::read_to_string(&head_path)?;
+    let head = head.trim();
+    let Some(ref_name) = head.strip_prefix("ref: ") else {
+        return Ok(head.to_string());
+    };
+
+    // Linked worktrees keep HEAD in their private git dir while refs live in
+    // the main repository's dir, pointed to by the `commondir` file.
+    let common_dir = match fs::read_to_string(git_dir.join("commondir")) {
+        Ok(dir) => {
+            let dir = dir.trim();
+            if Path::new(dir).is_absolute() {
+                PathBuf::from(dir)
+            } else {
+                git_dir.join(dir)
+            }
+        }
+        Err(_) => git_dir.to_path_buf(),
+    };
+
+    if let Ok(sha) = fs::read_to_string(common_dir.join(ref_name)) {
+        return Ok(sha.trim().to_string());
+    }
+
+    let packed = fs::read_to_string(common_dir.join("packed-refs"))?;
+    packed_ref_target(&packed, ref_name)
+        .ok_or_else(|| SwarmError::Git(format!("unresolved ref {ref_name} for {path}")))
+}
+
+fn packed_ref_target(packed_refs: &str, ref_name: &str) -> Option<String> {
+    for line in packed_refs.lines() {
+        if line.starts_with('#') || line.starts_with('^') {
+            continue;
+        }
+        if let Some((sha, name)) = line.split_once(' ')
+            && name == ref_name
+        {
+            return Some(sha.to_string());
+        }
+    }
+    None
 }
 
 pub fn workspace_head_path(path: &str) -> Result<PathBuf, SwarmError> {
@@ -553,4 +600,26 @@ fn render_git_failure(output: std::process::Output) -> String {
     }
 
     format!("exit status {}", output.status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::packed_ref_target;
+
+    #[test]
+    fn packed_ref_target_resolves_branches() {
+        let packed = "# pack-refs with: peeled fully-peeled sorted \n\
+            0123456789abcdef0123456789abcdef01234567 refs/heads/main\n\
+            89abcdef0123456789abcdef0123456789abcdef refs/heads/feature\n\
+            ^7777777777abcdef0123456789abcdef01234567\n";
+        assert_eq!(
+            packed_ref_target(packed, "refs/heads/feature").as_deref(),
+            Some("89abcdef0123456789abcdef0123456789abcdef")
+        );
+        assert_eq!(
+            packed_ref_target(packed, "refs/heads/main").as_deref(),
+            Some("0123456789abcdef0123456789abcdef01234567")
+        );
+        assert_eq!(packed_ref_target(packed, "refs/heads/missing"), None);
+    }
 }

--- a/ui/data.rs
+++ b/ui/data.rs
@@ -266,20 +266,18 @@ pub async fn create_session(workspace_ref: String) -> Result<SessionEntry, Swarm
     })
 }
 
-pub fn close_session(session_id: &str) -> Result<SessionEntry, SwarmError> {
-    exec::runtime().block_on(async {
-        let session_store = SessionStore::open().await?;
-        session_store.stop(session_id).await?;
-        let session = session_store.remove(session_id).await?;
+pub async fn close_session(session_id: String) -> Result<SessionEntry, SwarmError> {
+    let session_store = SessionStore::open().await?;
+    session_store.stop(&session_id).await?;
+    let session = session_store.remove(&session_id).await?;
 
-        Ok(SessionEntry {
-            id: session.id,
-            pid: session.pid,
-            program: session_program(session.pid, &session.command),
-            status: session.status,
-            log_path: session.log_path.display().to_string(),
-            socket_path: session.socket_path.display().to_string(),
-        })
+    Ok(SessionEntry {
+        id: session.id,
+        pid: session.pid,
+        program: session_program(session.pid, &session.command),
+        status: session.status,
+        log_path: session.log_path.display().to_string(),
+        socket_path: session.socket_path.display().to_string(),
     })
 }
 

--- a/ui/data.rs
+++ b/ui/data.rs
@@ -96,43 +96,41 @@ pub fn load_workspace_groups() -> Result<Vec<WorkspaceGroup>, SwarmError> {
     })
 }
 
-pub fn create_workspace(
-    repository: &str,
-    name: Option<&str>,
+pub async fn create_workspace(
+    repository: String,
+    name: Option<String>,
 ) -> Result<WorkspaceEntry, SwarmError> {
-    exec::runtime().block_on(async {
-        let repo_store = RepositoryStore::open().await?;
-        let workspace_store = WorkspaceStore::open().await?;
-        let session_store = SessionStore::open().await?;
+    let repo_store = RepositoryStore::open().await?;
+    let workspace_store = WorkspaceStore::open().await?;
+    let session_store = SessionStore::open().await?;
 
-        let repo = repo_store
-            .resolve_repository(repository)
-            .await?
-            .ok_or_else(|| SwarmError::RepositoryNotFound(repository.to_string()))?;
-        let workspace = workspace_store.create(repository, name).await?;
-        let workspace_ref = format!("{}:{}", workspace.repository, workspace.name);
-        if let Err(err) = session_store
-            .create(&workspace_ref, &default_session_command())
-            .await
-        {
-            eprintln!("failed to create default session for {workspace_ref}: {err}");
-        }
-        let sessions = session_store
-            .list(Some(&workspace_ref))
-            .await?
-            .into_iter()
-            .map(|session| SessionEntry {
-                pid: session.pid,
-                program: session_program(session.pid, &session.command),
-                id: session.id,
-                status: session.status,
-                log_path: session.log_path.display().to_string(),
-                socket_path: session.socket_path.display().to_string(),
-            })
-            .collect::<Vec<_>>();
+    let repo = repo_store
+        .resolve_repository(&repository)
+        .await?
+        .ok_or_else(|| SwarmError::RepositoryNotFound(repository.clone()))?;
+    let workspace = workspace_store.create(&repository, name.as_deref()).await?;
+    let workspace_ref = format!("{}:{}", workspace.repository, workspace.name);
+    if let Err(err) = session_store
+        .create(&workspace_ref, &default_session_command())
+        .await
+    {
+        eprintln!("failed to create default session for {workspace_ref}: {err}");
+    }
+    let sessions = session_store
+        .list(Some(&workspace_ref))
+        .await?
+        .into_iter()
+        .map(|session| SessionEntry {
+            pid: session.pid,
+            program: session_program(session.pid, &session.command),
+            id: session.id,
+            status: session.status,
+            log_path: session.log_path.display().to_string(),
+            socket_path: session.socket_path.display().to_string(),
+        })
+        .collect::<Vec<_>>();
 
-        Ok(map_workspace(&repo.canonical(), workspace, sessions))
-    })
+    Ok(map_workspace(&repo.canonical(), workspace, sessions))
 }
 
 pub fn add_repository(repository: &str, alias: Option<&str>) -> Result<Repository, SwarmError> {
@@ -193,39 +191,40 @@ pub fn rename_workspace(workspace_ref: &str, name: &str) -> Result<WorkspaceEntr
     })
 }
 
-pub fn clone_workspace(workspace_ref: &str, name: &str) -> Result<WorkspaceEntry, SwarmError> {
-    exec::runtime().block_on(async {
-        let repo_store = RepositoryStore::open().await?;
-        let workspace_store = WorkspaceStore::open().await?;
-        let session_store = SessionStore::open().await?;
-        let workspace = workspace_store.clone(workspace_ref, name).await?;
-        let repo = repo_store
-            .resolve_repository(&workspace.repository)
-            .await?
-            .ok_or_else(|| SwarmError::RepositoryNotFound(workspace.repository.clone()))?;
-        let workspace_ref = format!("{}:{}", workspace.repository, workspace.name);
-        if let Err(err) = session_store
-            .create(&workspace_ref, &default_session_command())
-            .await
-        {
-            eprintln!("failed to create default session for {workspace_ref}: {err}");
-        }
-        let sessions = session_store
-            .list(Some(&workspace_ref))
-            .await?
-            .into_iter()
-            .map(|session| SessionEntry {
-                pid: session.pid,
-                program: session_program(session.pid, &session.command),
-                id: session.id,
-                status: session.status,
-                log_path: session.log_path.display().to_string(),
-                socket_path: session.socket_path.display().to_string(),
-            })
-            .collect::<Vec<_>>();
+pub async fn clone_workspace(
+    workspace_ref: String,
+    name: String,
+) -> Result<WorkspaceEntry, SwarmError> {
+    let repo_store = RepositoryStore::open().await?;
+    let workspace_store = WorkspaceStore::open().await?;
+    let session_store = SessionStore::open().await?;
+    let workspace = workspace_store.clone(&workspace_ref, &name).await?;
+    let repo = repo_store
+        .resolve_repository(&workspace.repository)
+        .await?
+        .ok_or_else(|| SwarmError::RepositoryNotFound(workspace.repository.clone()))?;
+    let workspace_ref = format!("{}:{}", workspace.repository, workspace.name);
+    if let Err(err) = session_store
+        .create(&workspace_ref, &default_session_command())
+        .await
+    {
+        eprintln!("failed to create default session for {workspace_ref}: {err}");
+    }
+    let sessions = session_store
+        .list(Some(&workspace_ref))
+        .await?
+        .into_iter()
+        .map(|session| SessionEntry {
+            pid: session.pid,
+            program: session_program(session.pid, &session.command),
+            id: session.id,
+            status: session.status,
+            log_path: session.log_path.display().to_string(),
+            socket_path: session.socket_path.display().to_string(),
+        })
+        .collect::<Vec<_>>();
 
-        Ok(map_workspace(&repo.canonical(), workspace, sessions))
-    })
+    Ok(map_workspace(&repo.canonical(), workspace, sessions))
 }
 
 pub fn remove_workspace(workspace_ref: &str) -> Result<WorkspaceEntry, SwarmError> {

--- a/ui/data.rs
+++ b/ui/data.rs
@@ -60,7 +60,7 @@ pub async fn load_workspace_groups() -> Result<Vec<WorkspaceGroup>, SwarmError> 
                 .into_iter()
                 .map(|session| SessionEntry {
                     pid: session.pid,
-                    program: session_program(session.pid, &session.command),
+                    program: command_program(&session.command),
                     id: session.id,
                     status: session.status,
                     log_path: session.log_path.display().to_string(),
@@ -115,7 +115,7 @@ pub async fn create_workspace(
         .into_iter()
         .map(|session| SessionEntry {
             pid: session.pid,
-            program: session_program(session.pid, &session.command),
+            program: command_program(&session.command),
             id: session.id,
             status: session.status,
             log_path: session.log_path.display().to_string(),
@@ -172,7 +172,7 @@ pub async fn rename_workspace(
         .into_iter()
         .map(|session| SessionEntry {
             pid: session.pid,
-            program: session_program(session.pid, &session.command),
+            program: command_program(&session.command),
             id: session.id,
             status: session.status,
             log_path: session.log_path.display().to_string(),
@@ -208,7 +208,7 @@ pub async fn clone_workspace(
         .into_iter()
         .map(|session| SessionEntry {
             pid: session.pid,
-            program: session_program(session.pid, &session.command),
+            program: command_program(&session.command),
             id: session.id,
             status: session.status,
             log_path: session.log_path.display().to_string(),
@@ -248,7 +248,7 @@ pub async fn create_session(workspace_ref: String) -> Result<SessionEntry, Swarm
     Ok(SessionEntry {
         id: session.id,
         pid: session.pid,
-        program: session_program(session.pid, &session.command),
+        program: command_program(&session.command),
         status: session.status,
         log_path: session.log_path.display().to_string(),
         socket_path: session.socket_path.display().to_string(),
@@ -263,7 +263,7 @@ pub async fn close_session(session_id: String) -> Result<SessionEntry, SwarmErro
     Ok(SessionEntry {
         id: session.id,
         pid: session.pid,
-        program: session_program(session.pid, &session.command),
+        program: command_program(&session.command),
         status: session.status,
         log_path: session.log_path.display().to_string(),
         socket_path: session.socket_path.display().to_string(),
@@ -379,10 +379,6 @@ fn pluralize(value: u64, unit: &str) -> String {
     } else {
         format!("{value} {unit}s ago")
     }
-}
-
-fn session_program(pid: Option<u32>, command: &[String]) -> String {
-    foreground_program(pid).unwrap_or_else(|| command_program(command))
 }
 
 pub fn foreground_program(pid: Option<u32>) -> Option<String> {

--- a/ui/data.rs
+++ b/ui/data.rs
@@ -133,11 +133,12 @@ pub async fn create_workspace(
     Ok(map_workspace(&repo.canonical(), workspace, sessions))
 }
 
-pub fn add_repository(repository: &str, alias: Option<&str>) -> Result<Repository, SwarmError> {
-    exec::runtime().block_on(async {
-        let repo_store = RepositoryStore::open().await?;
-        repo_store.add(repository, alias).await
-    })
+pub async fn add_repository(
+    repository: String,
+    alias: Option<String>,
+) -> Result<Repository, SwarmError> {
+    let repo_store = RepositoryStore::open().await?;
+    repo_store.add(&repository, alias.as_deref()).await
 }
 
 pub async fn sync_repository(repository: String) -> Result<(), SwarmError> {
@@ -146,49 +147,47 @@ pub async fn sync_repository(repository: String) -> Result<(), SwarmError> {
     Ok(())
 }
 
-pub fn collapse_repository(repository: &str) -> Result<(), SwarmError> {
-    exec::runtime().block_on(async {
-        let repo_store = RepositoryStore::open().await?;
-        repo_store.collapse(repository).await?;
-        Ok(())
-    })
+pub async fn set_repository_collapsed(
+    repository: String,
+    collapsed: bool,
+) -> Result<(), SwarmError> {
+    let repo_store = RepositoryStore::open().await?;
+    if collapsed {
+        repo_store.collapse(&repository).await?;
+    } else {
+        repo_store.expand(&repository).await?;
+    }
+    Ok(())
 }
 
-pub fn expand_repository(repository: &str) -> Result<(), SwarmError> {
-    exec::runtime().block_on(async {
-        let repo_store = RepositoryStore::open().await?;
-        repo_store.expand(repository).await?;
-        Ok(())
-    })
-}
+pub async fn rename_workspace(
+    workspace_ref: String,
+    name: String,
+) -> Result<WorkspaceEntry, SwarmError> {
+    let repo_store = RepositoryStore::open().await?;
+    let workspace_store = WorkspaceStore::open().await?;
+    let session_store = SessionStore::open().await?;
+    let workspace = workspace_store.rename(&workspace_ref, &name).await?;
+    let repo = repo_store
+        .resolve_repository(&workspace.repository)
+        .await?
+        .ok_or_else(|| SwarmError::RepositoryNotFound(workspace.repository.clone()))?;
+    let workspace_ref = format!("{}:{}", workspace.repository, workspace.name);
+    let sessions = session_store
+        .list(Some(&workspace_ref))
+        .await?
+        .into_iter()
+        .map(|session| SessionEntry {
+            pid: session.pid,
+            program: session_program(session.pid, &session.command),
+            id: session.id,
+            status: session.status,
+            log_path: session.log_path.display().to_string(),
+            socket_path: session.socket_path.display().to_string(),
+        })
+        .collect::<Vec<_>>();
 
-pub fn rename_workspace(workspace_ref: &str, name: &str) -> Result<WorkspaceEntry, SwarmError> {
-    exec::runtime().block_on(async {
-        let repo_store = RepositoryStore::open().await?;
-        let workspace_store = WorkspaceStore::open().await?;
-        let session_store = SessionStore::open().await?;
-        let workspace = workspace_store.rename(workspace_ref, name).await?;
-        let repo = repo_store
-            .resolve_repository(&workspace.repository)
-            .await?
-            .ok_or_else(|| SwarmError::RepositoryNotFound(workspace.repository.clone()))?;
-        let workspace_ref = format!("{}:{}", workspace.repository, workspace.name);
-        let sessions = session_store
-            .list(Some(&workspace_ref))
-            .await?
-            .into_iter()
-            .map(|session| SessionEntry {
-                pid: session.pid,
-                program: session_program(session.pid, &session.command),
-                id: session.id,
-                status: session.status,
-                log_path: session.log_path.display().to_string(),
-                socket_path: session.socket_path.display().to_string(),
-            })
-            .collect::<Vec<_>>();
-
-        Ok(map_workspace(&repo.canonical(), workspace, sessions))
-    })
+    Ok(map_workspace(&repo.canonical(), workspace, sessions))
 }
 
 pub async fn clone_workspace(
@@ -227,26 +226,24 @@ pub async fn clone_workspace(
     Ok(map_workspace(&repo.canonical(), workspace, sessions))
 }
 
-pub fn remove_workspace(workspace_ref: &str) -> Result<WorkspaceEntry, SwarmError> {
-    exec::runtime().block_on(async {
-        let repo_store = RepositoryStore::open().await?;
-        let session_store = SessionStore::open().await?;
-        let workspace_store = WorkspaceStore::open().await?;
-        let sessions = session_store.list(Some(workspace_ref)).await?;
+pub async fn remove_workspace(workspace_ref: String) -> Result<WorkspaceEntry, SwarmError> {
+    let repo_store = RepositoryStore::open().await?;
+    let session_store = SessionStore::open().await?;
+    let workspace_store = WorkspaceStore::open().await?;
+    let sessions = session_store.list(Some(&workspace_ref)).await?;
 
-        for session in sessions {
-            session_store.stop(&session.id).await?;
-            session_store.remove(&session.id).await?;
-        }
+    for session in sessions {
+        session_store.stop(&session.id).await?;
+        session_store.remove(&session.id).await?;
+    }
 
-        let workspace = workspace_store.remove(workspace_ref).await?;
-        let repo = repo_store
-            .resolve_repository(&workspace.repository)
-            .await?
-            .ok_or_else(|| SwarmError::RepositoryNotFound(workspace.repository.clone()))?;
+    let workspace = workspace_store.remove(&workspace_ref).await?;
+    let repo = repo_store
+        .resolve_repository(&workspace.repository)
+        .await?
+        .ok_or_else(|| SwarmError::RepositoryNotFound(workspace.repository.clone()))?;
 
-        Ok(map_workspace(&repo.canonical(), workspace, Vec::new()))
-    })
+    Ok(map_workspace(&repo.canonical(), workspace, Vec::new()))
 }
 
 pub async fn create_session(workspace_ref: String) -> Result<SessionEntry, SwarmError> {

--- a/ui/data.rs
+++ b/ui/data.rs
@@ -142,12 +142,10 @@ pub fn add_repository(repository: &str, alias: Option<&str>) -> Result<Repositor
     })
 }
 
-pub fn sync_repository(repository: &str) -> Result<(), SwarmError> {
-    exec::runtime().block_on(async {
-        let repo_store = RepositoryStore::open().await?;
-        repo_store.sync(repository).await?;
-        Ok(())
-    })
+pub async fn sync_repository(repository: String) -> Result<(), SwarmError> {
+    let repo_store = RepositoryStore::open().await?;
+    repo_store.sync(&repository).await?;
+    Ok(())
 }
 
 pub fn collapse_repository(repository: &str) -> Result<(), SwarmError> {

--- a/ui/exec.rs
+++ b/ui/exec.rs
@@ -11,7 +11,6 @@ pub fn runtime() -> &'static Runtime {
 /// Runs `work` on the shared runtime and delivers its result to `on_done` on
 /// the GTK main thread. Must be called from the main thread. If the work
 /// panics, `on_done` is never called.
-#[expect(dead_code, reason = "call sites arrive with the dispatch conversions")]
 pub fn dispatch<T, Fut, Done>(work: Fut, on_done: Done)
 where
     T: Send + 'static,

--- a/ui/exec.rs
+++ b/ui/exec.rs
@@ -24,3 +24,19 @@ where
         }
     });
 }
+
+/// Like [`dispatch`], for synchronous work (subprocesses, filesystem walks)
+/// that would otherwise pin a runtime worker thread.
+pub fn dispatch_blocking<T, Work, Done>(work: Work, on_done: Done)
+where
+    T: Send + 'static,
+    Work: FnOnce() -> T + Send + 'static,
+    Done: FnOnce(T) + 'static,
+{
+    let handle = runtime().spawn_blocking(work);
+    glib::spawn_future_local(async move {
+        if let Ok(result) = handle.await {
+            on_done(result);
+        }
+    });
+}

--- a/ui/exec.rs
+++ b/ui/exec.rs
@@ -1,0 +1,27 @@
+use gtk::glib;
+use std::{future::Future, sync::OnceLock};
+use tokio::runtime::Runtime;
+
+/// Returns the process-wide tokio runtime used for all background work.
+pub fn runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| Runtime::new().expect("failed to create tokio runtime"))
+}
+
+/// Runs `work` on the shared runtime and delivers its result to `on_done` on
+/// the GTK main thread. Must be called from the main thread. If the work
+/// panics, `on_done` is never called.
+#[expect(dead_code, reason = "call sites arrive with the dispatch conversions")]
+pub fn dispatch<T, Fut, Done>(work: Fut, on_done: Done)
+where
+    T: Send + 'static,
+    Fut: Future<Output = T> + Send + 'static,
+    Done: FnOnce(T) + 'static,
+{
+    let handle = runtime().spawn(work);
+    glib::spawn_future_local(async move {
+        if let Ok(result) = handle.await {
+            on_done(result);
+        }
+    });
+}

--- a/ui/swarm.rs
+++ b/ui/swarm.rs
@@ -1,5 +1,6 @@
 mod app;
 mod data;
+mod exec;
 mod ghostty;
 mod workspace_panel;
 

--- a/ui/workspace_panel.rs
+++ b/ui/workspace_panel.rs
@@ -130,8 +130,8 @@ impl DetailWidgets {
         {
             let state = state.clone();
             let workspace_ref = workspace_ref(workspace);
-            add_button.connect_clicked(move |_| {
-                create_and_select_session(&state, &workspace_ref);
+            add_button.connect_clicked(move |button| {
+                create_and_select_session(&state, &workspace_ref, button);
             });
         }
         self.session_toolbar.append(&add_button);
@@ -341,8 +341,8 @@ fn build_empty_session_placeholder(state: &Rc<AppState>, workspace: &WorkspaceEn
     {
         let state = state.clone();
         let workspace_id = workspace_ref(workspace);
-        new_terminal.connect_clicked(move |_| {
-            create_and_select_session(&state, &workspace_id);
+        new_terminal.connect_clicked(move |button| {
+            create_and_select_session(&state, &workspace_id, button);
         });
     }
 
@@ -622,29 +622,48 @@ fn sync_session_tab_labels(session_tabs: &GtkBox, programs: &[(String, String)])
     }
 }
 
-fn create_and_select_session(state: &Rc<AppState>, workspace_id: &str) {
-    match create_session(workspace_id) {
-        Ok(session) => {
-            let mut next_groups = current_groups(state);
-            for group in &mut next_groups {
-                if let Some(workspace) = group
-                    .workspaces
-                    .iter_mut()
-                    .find(|workspace| workspace_ref(workspace) == workspace_id)
-                {
-                    workspace.sessions.push(session.clone());
-                    break;
-                }
-            }
-            *state.workspace_groups.borrow_mut() = next_groups.clone();
-            *state.selected_workspace.borrow_mut() = Some(workspace_id.to_string());
-            remember_selected_session(state, workspace_id, Some(&session.id));
-            schedule_render_current_ui(state, Some(workspace_id.to_string()), Some(session.id));
-        }
-        Err(err) => {
-            eprintln!("failed to create session: {err}");
-        }
+fn create_and_select_session(state: &Rc<AppState>, workspace_id: &str, button: &Button) {
+    if !state
+        .creating_session_workspaces
+        .borrow_mut()
+        .insert(workspace_id.to_string())
+    {
+        return;
     }
+    button.set_sensitive(false);
+
+    let state = state.clone();
+    let workspace_id = workspace_id.to_string();
+    let button = button.clone();
+    exec::dispatch(create_session(workspace_id.clone()), move |result| {
+        state
+            .creating_session_workspaces
+            .borrow_mut()
+            .remove(&workspace_id);
+        button.set_sensitive(true);
+        match result {
+            Ok(session) => {
+                let mut next_groups = current_groups(&state);
+                for group in &mut next_groups {
+                    if let Some(workspace) = group
+                        .workspaces
+                        .iter_mut()
+                        .find(|workspace| workspace_ref(workspace) == workspace_id)
+                    {
+                        workspace.sessions.push(session.clone());
+                        break;
+                    }
+                }
+                *state.workspace_groups.borrow_mut() = next_groups.clone();
+                *state.selected_workspace.borrow_mut() = Some(workspace_id.clone());
+                remember_selected_session(&state, &workspace_id, Some(&session.id));
+                schedule_render_current_ui(&state, Some(workspace_id.clone()), Some(session.id));
+            }
+            Err(err) => {
+                eprintln!("failed to create session: {err}");
+            }
+        }
+    });
 }
 
 fn close_specific_session(

--- a/ui/workspace_panel.rs
+++ b/ui/workspace_panel.rs
@@ -1,24 +1,24 @@
 use gtk::{
-    glib, prelude::*, Align, Box as GtkBox, Button, Image, Label, LinkButton, Orientation, Stack,
+    Align, Box as GtkBox, Button, Image, Label, LinkButton, Orientation, Stack, glib, prelude::*,
 };
 use std::{
     cell::RefCell,
     collections::HashMap,
     path::Path,
     rc::Rc,
-    sync::{mpsc, Arc, Mutex},
+    sync::{Arc, Mutex, mpsc},
     time::Duration,
 };
 use swarm::forges::github::{self, PullRequestStatus};
 
 use crate::{
     app::{
-        clear_box, clear_workspace_pr_status, current_groups, preferred_session_for_workspace,
-        remember_selected_session, render_selected_workspace_detail, request_workspace_pr_status,
-        schedule_render_current_ui, workspace_pr_snapshot, workspace_ref, AppState,
-        CreatePrEligibility, WorkspacePrState,
+        AppState, CreatePrEligibility, WorkspacePrState, clear_box, clear_workspace_pr_status,
+        current_groups, preferred_session_for_workspace, remember_selected_session,
+        render_selected_workspace_detail, request_workspace_pr_status, schedule_render_current_ui,
+        workspace_pr_snapshot, workspace_ref,
     },
-    data::{close_session, create_session, foreground_program, SessionEntry, WorkspaceEntry},
+    data::{SessionEntry, WorkspaceEntry, close_session, create_session, foreground_program},
     exec, ghostty,
 };
 
@@ -144,7 +144,8 @@ impl DetailWidgets {
                 }
             }
             WorkspacePrState::None(eligibility) => {
-                if let Some(button) = build_workspace_create_pr_button(state, workspace, eligibility)
+                if let Some(button) =
+                    build_workspace_create_pr_button(state, workspace, eligibility)
                 {
                     self.session_toolbar.append(&button);
                 }
@@ -285,7 +286,8 @@ impl DetailWidgets {
                 }
             }
             WorkspacePrState::None(eligibility) => {
-                if let Some(button) = build_workspace_create_pr_button(state, workspace, eligibility)
+                if let Some(button) =
+                    build_workspace_create_pr_button(state, workspace, eligibility)
                 {
                     self.session_toolbar.append(&button);
                 }
@@ -569,24 +571,26 @@ fn install_session_program_refresh(session_tabs: &GtkBox, tracked: TrackedSessio
     let session_tabs = session_tabs.downgrade();
     let (tx, rx) = mpsc::channel::<Vec<(String, String)>>();
 
-    std::thread::spawn(move || loop {
-        std::thread::sleep(Duration::from_secs(1));
-        let Ok(sessions) = tracked.lock().map(|sessions| sessions.clone()) else {
-            break;
-        };
-        if sessions.is_empty() {
-            continue;
-        }
+    std::thread::spawn(move || {
+        loop {
+            std::thread::sleep(Duration::from_secs(1));
+            let Ok(sessions) = tracked.lock().map(|sessions| sessions.clone()) else {
+                break;
+            };
+            if sessions.is_empty() {
+                continue;
+            }
 
-        let programs: Vec<(String, String)> = sessions
-            .iter()
-            .map(|(id, pid, fallback)| {
-                let program = foreground_program(*pid).unwrap_or_else(|| fallback.clone());
-                (id.clone(), program)
-            })
-            .collect();
-        if tx.send(programs).is_err() {
-            break;
+            let programs: Vec<(String, String)> = sessions
+                .iter()
+                .map(|(id, pid, fallback)| {
+                    let program = foreground_program(*pid).unwrap_or_else(|| fallback.clone());
+                    (id.clone(), program)
+                })
+                .collect();
+            if tx.send(programs).is_err() {
+                break;
+            }
         }
     });
 

--- a/ui/workspace_panel.rs
+++ b/ui/workspace_panel.rs
@@ -16,7 +16,7 @@ use crate::{
         clear_box, clear_workspace_pr_status, current_groups, preferred_session_for_workspace,
         remember_selected_session, render_selected_workspace_detail, request_workspace_pr_status,
         schedule_render_current_ui, workspace_pr_snapshot, workspace_ref, AppState,
-        WorkspacePrState,
+        CreatePrEligibility, WorkspacePrState,
     },
     data::{close_session, create_session, foreground_program, SessionEntry, WorkspaceEntry},
     exec, ghostty,
@@ -143,8 +143,9 @@ impl DetailWidgets {
                     self.session_toolbar.append(&link);
                 }
             }
-            WorkspacePrState::None => {
-                if let Some(button) = build_workspace_create_pr_button(state, workspace) {
+            WorkspacePrState::None(eligibility) => {
+                if let Some(button) = build_workspace_create_pr_button(state, workspace, eligibility)
+                {
                     self.session_toolbar.append(&button);
                 }
             }
@@ -283,8 +284,9 @@ impl DetailWidgets {
                     self.session_toolbar.append(&link);
                 }
             }
-            WorkspacePrState::None => {
-                if let Some(button) = build_workspace_create_pr_button(state, workspace) {
+            WorkspacePrState::None(eligibility) => {
+                if let Some(button) = build_workspace_create_pr_button(state, workspace, eligibility)
+                {
                     self.session_toolbar.append(&button);
                 }
             }
@@ -373,9 +375,9 @@ fn build_workspace_pr_link(status: &PullRequestStatus) -> Option<LinkButton> {
 fn build_workspace_create_pr_button(
     state: &Rc<AppState>,
     workspace: &WorkspaceEntry,
+    eligibility: CreatePrEligibility,
 ) -> Option<Button> {
-    let workspace_path = Path::new(&workspace.path);
-    if !github::is_github_workspace(workspace_path) {
+    if !eligibility.is_github {
         return None;
     }
 
@@ -384,7 +386,7 @@ fn build_workspace_create_pr_button(
         .creating_pr_workspaces
         .borrow()
         .contains(&workspace_id);
-    let commits_ahead = github::workspace_commits_ahead(workspace_path);
+    let commits_ahead = eligibility.commits_ahead;
 
     let (label, tooltip, enabled) = if in_flight {
         ("Creating PR…", "Creating pull request".to_string(), false)

--- a/ui/workspace_panel.rs
+++ b/ui/workspace_panel.rs
@@ -19,7 +19,7 @@ use crate::{
         WorkspacePrState,
     },
     data::{close_session, create_session, foreground_program, SessionEntry, WorkspaceEntry},
-    ghostty,
+    exec, ghostty,
 };
 
 #[derive(Clone)]
@@ -446,59 +446,30 @@ fn start_pr_creation(state: &Rc<AppState>, workspace: &WorkspaceEntry) {
     }
 
     let workspace_path = workspace.path.clone();
-    let (sender, receiver) = mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = sender.send(github::create_pull_request(Path::new(&workspace_path)));
-    });
+    let state = state.clone();
+    let workspace = workspace.clone();
+    exec::dispatch_blocking(
+        move || github::create_pull_request(Path::new(&workspace_path)),
+        move |result| {
+            state
+                .creating_pr_workspaces
+                .borrow_mut()
+                .remove(&workspace_id);
 
-    let state_for_completion = state.clone();
-    let workspace_id_for_completion = workspace_id.clone();
-    let workspace_for_completion = workspace.clone();
-    glib::timeout_add_local(Duration::from_millis(50), move || {
-        match receiver.try_recv() {
-            Ok(result) => {
-                state_for_completion
-                    .creating_pr_workspaces
-                    .borrow_mut()
-                    .remove(&workspace_id_for_completion);
-
-                if let Err(err) = &result {
-                    eprintln!(
-                        "failed to create pull request for {workspace_id_for_completion}: {err}"
-                    );
-                }
-
-                clear_workspace_pr_status(&state_for_completion, &workspace_id_for_completion);
-                request_workspace_pr_status(&state_for_completion, &workspace_for_completion, true);
-
-                if let Some(selected) = state_for_completion.selected_workspace.borrow().clone() {
-                    if selected == workspace_id_for_completion {
-                        render_selected_workspace_detail(&state_for_completion, &selected, None);
-                    }
-                }
-
-                glib::ControlFlow::Break
+            if let Err(err) = result {
+                eprintln!("failed to create pull request for {workspace_id}: {err}");
             }
-            Err(mpsc::TryRecvError::Empty) => glib::ControlFlow::Continue,
-            Err(mpsc::TryRecvError::Disconnected) => {
-                state_for_completion
-                    .creating_pr_workspaces
-                    .borrow_mut()
-                    .remove(&workspace_id_for_completion);
-                eprintln!(
-                    "failed to create pull request for {workspace_id_for_completion}: worker disconnected"
-                );
 
-                if let Some(selected) = state_for_completion.selected_workspace.borrow().clone() {
-                    if selected == workspace_id_for_completion {
-                        render_selected_workspace_detail(&state_for_completion, &selected, None);
-                    }
+            clear_workspace_pr_status(&state, &workspace_id);
+            request_workspace_pr_status(&state, &workspace, true);
+
+            if let Some(selected) = state.selected_workspace.borrow().clone() {
+                if selected == workspace_id {
+                    render_selected_workspace_detail(&state, &selected, None);
                 }
-
-                glib::ControlFlow::Break
             }
-        }
-    });
+        },
+    );
 }
 
 fn clear_stack(stack: &Stack) {

--- a/ui/workspace_panel.rs
+++ b/ui/workspace_panel.rs
@@ -672,37 +672,51 @@ fn close_specific_session(
     session_ids: &[String],
     session_id: &str,
 ) {
+    if !state
+        .closing_sessions
+        .borrow_mut()
+        .insert(session_id.to_string())
+    {
+        return;
+    }
+
     let next_selected = session_ids
         .iter()
         .find(|id| id.as_str() != session_id)
         .cloned();
 
-    match close_session(session_id) {
-        Ok(_) => {
-            if let Some(detail_widgets) = state.detail_widgets.borrow().as_ref() {
-                detail_widgets.evict_terminals([session_id]);
-            }
-            let preferred_session = next_selected.clone();
-            let mut next_groups = current_groups(state);
-            for group in &mut next_groups {
-                if let Some(workspace) = group
-                    .workspaces
-                    .iter_mut()
-                    .find(|workspace| workspace_ref(workspace) == workspace_id)
-                {
-                    workspace
-                        .sessions
-                        .retain(|session| session.id != session_id);
-                    break;
+    let state = state.clone();
+    let workspace_id = workspace_id.to_string();
+    let session_id = session_id.to_string();
+    exec::dispatch(close_session(session_id.clone()), move |result| {
+        state.closing_sessions.borrow_mut().remove(&session_id);
+        match result {
+            Ok(_) => {
+                if let Some(detail_widgets) = state.detail_widgets.borrow().as_ref() {
+                    detail_widgets.evict_terminals([session_id.as_str()]);
                 }
+                let preferred_session = next_selected.clone();
+                let mut next_groups = current_groups(&state);
+                for group in &mut next_groups {
+                    if let Some(workspace) = group
+                        .workspaces
+                        .iter_mut()
+                        .find(|workspace| workspace_ref(workspace) == workspace_id)
+                    {
+                        workspace
+                            .sessions
+                            .retain(|session| session.id != session_id);
+                        break;
+                    }
+                }
+                *state.workspace_groups.borrow_mut() = next_groups.clone();
+                *state.selected_workspace.borrow_mut() = Some(workspace_id.clone());
+                remember_selected_session(&state, &workspace_id, next_selected.as_deref());
+                schedule_render_current_ui(&state, Some(workspace_id.clone()), preferred_session);
             }
-            *state.workspace_groups.borrow_mut() = next_groups.clone();
-            *state.selected_workspace.borrow_mut() = Some(workspace_id.to_string());
-            remember_selected_session(state, workspace_id, next_selected.as_deref());
-            schedule_render_current_ui(state, Some(workspace_id.to_string()), preferred_session);
+            Err(err) => {
+                eprintln!("failed to close session: {err}");
+            }
         }
-        Err(err) => {
-            eprintln!("failed to close session: {err}");
-        }
-    }
+    });
 }


### PR DESCRIPTION
## Problem

Creating or killing a terminal (and other UI actions) occasionally froze the app long enough for the compositor to show its "not responding" dialog.

The root cause was structural: every function in `ui/data.rs` constructed a fresh tokio runtime and ran `block_on` directly in the GTK click handler. The worst offenders:

- **Terminal create** blocked on three store opens, spawning the supervisor, and a readiness poll with a 3-second deadline.
- **Terminal close** blocked on two full session lookups (each opening every repository database), a status refresh, and `fs::remove_dir_all` of the session directory — multi-second for sessions with large logs.
- `load_workspace_groups` ran on the main thread on startup and every refresh, including a full `/proc` scan per session.
- Rendering spawned `git`/`gh` subprocesses (Create-PR eligibility, head-change detection), retriggered by the 1-second PR scheduler.

## Approach

One structural pattern, applied everywhere: **dispatch + apply**.

- `ui/exec.rs` holds a process-wide tokio runtime and two bridges: `dispatch()` for futures and `dispatch_blocking()` for subprocess/filesystem work.
- Results come back to the GTK main loop via `glib::spawn_future_local`, so completion handlers keep using the existing `Rc<AppState>`/`RefCell` model unchanged — no locks, no `Send` bounds on UI state.
- Handlers follow three phases: record pending state (in-flight guard, button desensitized) → dispatch the async `data.rs` call → patch cached groups and re-render in the completion handler.

This also replaced the three pre-existing hand-rolled thread + mpsc + 50 ms poll-timer loops (repo sync, PR create, PR status pump), which were the boilerplate that made `block_on` the path of least resistance.

## Result

- The main thread contains **no** `block_on`, subprocess spawns, `/proc` scans, or directory deletes. The remaining blocking primitives in `ui/` are intentional: `run_git` only executes inside dispatched work, and the session program refresh worker owns its polling thread.
- Session readiness waiting uses `tokio::time::sleep` instead of pinning a runtime worker (enables tokio's `time` feature; CLI behavior unchanged).
- Create-PR eligibility is resolved in the background PR lookup and cached; head-change detection reads git's files directly (loose refs, packed-refs, linked worktrees) instead of spawning `rev-parse`, with a unit test for packed-refs parsing.
- Double-clicks on create/close/clone/delete are absorbed by in-flight guards.

Each commit is a self-contained step (the series converts one call site at a time and keeps the app working throughout), verified with `cargo build --locked`, `cargo test --locked` (default and `--no-default-features`), and `cargo clippy --all-targets` at every step.

## Testing

- 24 tests pass across both feature configurations; clippy warning count unchanged from `main`.
- Manual pass: create/kill terminals, workspace create/clone/rename/remove, add repository, sync, Create PR — window stays responsive throughout.